### PR TITLE
Sales breakdown

### DIFF
--- a/excise/tasks.py
+++ b/excise/tasks.py
@@ -51,7 +51,7 @@ def api_post_request_task(
     msg = ""
     if not tax_response:
         msg = (
-            "Empty response received from Excise API, " f"Order: {order.token}"
+            f"Empty response received from Excise API, order: {order.token}"
         )
         logger.warning(
             "Empty response received from Excise API, Order: %s", order.token

--- a/excise/tasks.py
+++ b/excise/tasks.py
@@ -1,19 +1,13 @@
-import json
 import logging
 
 import opentracing
 import opentracing.tags
-
 from saleor.celeryconf import app
 from saleor.core.taxes import TaxError
 from saleor.order.events import external_notification_event
 from saleor.order.models import Order
-from .utils import (
-    AvataxConfiguration,
-    api_post_request,
-    get_metadata_key,
-    build_metadata
-)
+
+from .utils import AvataxConfiguration, api_post_request, build_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +51,10 @@ def api_post_request_task(
     msg = ""
     if not tax_response:
         msg = (
-            "Empty response received from Excise API, "
-            f"Order: {order.token}"
+            "Empty response received from Excise API, " f"Order: {order.token}"
         )
         logger.warning(
-            "Empty response received from Excise API, Order: %s",
-            order.token
+            "Empty response received from Excise API, Order: %s", order.token
         )
         external_notification_event(
             order=order, user=None, app=None, message=msg, parameters=None
@@ -70,10 +62,9 @@ def api_post_request_task(
         return
     elif tax_response.get("ReturnCode", -1) != 0:
         errors = tax_response.get("TransactionErrors", [])
-        error_msg = ". ".join([
-            error.get("ErrorMessage", "")
-            for error in errors
-        ])
+        error_msg = ". ".join(
+            [error.get("ErrorMessage", "") for error in errors]
+        )
         msg = f"Unable to send order to Avatax Excise. {error_msg}"
         logger.warning(
             "Unable to send order %s to Avatax Excise. Response %s",
@@ -95,13 +86,12 @@ def api_post_request_task(
                 config,
             )
             msg = f"Order committed to Avatax Excise. Order ID: {order.token}"
-            commit_status = commit_response.get("Status", '')
+            commit_status = commit_response.get("Status", "")
             if not commit_response or "Error" in commit_status:
                 errors = commit_response.get("TransactionErrors", [])
-                error_msg = ". ".join([
-                    error.get("ErrorMessage", "")
-                    for error in errors
-                ])
+                error_msg = ". ".join(
+                    [error.get("ErrorMessage", "") for error in errors]
+                )
                 msg = f"Unable to commit order to Avatax Excise. {error_msg}"
                 logger.warning(
                     "Unable to commit order %s to Avatax Excise. Response %s",

--- a/excise/tasks.py
+++ b/excise/tasks.py
@@ -41,7 +41,7 @@ def api_post_request_task(
             "sent to Avatax Excise."
         )
         external_notification_event(
-            order=order, user=None, message=msg, parameters=None
+            order=order, user=None, app=None, message=msg, parameters=None
         )
         return
 
@@ -65,7 +65,7 @@ def api_post_request_task(
             order.token
         )
         external_notification_event(
-            order=order, user=None, message=msg, parameters=None
+            order=order, user=None, app=None, message=msg, parameters=None
         )
         return
     elif tax_response.get("ReturnCode", -1) != 0:
@@ -81,7 +81,7 @@ def api_post_request_task(
             tax_response,
         )
         external_notification_event(
-            order=order, user=None, message=msg, parameters=None
+            order=order, user=None, app=None, message=msg, parameters=None
         )
         return
     else:
@@ -114,5 +114,5 @@ def api_post_request_task(
     order.save()
 
     external_notification_event(
-        order=order, user=None, message=msg, parameters=None
+        order=order, user=None, app=None, message=msg, parameters=None
     )

--- a/excise/tasks.py
+++ b/excise/tasks.py
@@ -12,6 +12,7 @@ from .utils import (
     AvataxConfiguration,
     api_post_request,
     get_metadata_key,
+    build_metadata
 )
 
 logger = logging.getLogger(__name__)
@@ -108,14 +109,7 @@ def api_post_request_task(
                     commit_response,
                 )
 
-    tax_metadata = {
-        get_metadata_key("itemized_taxes"): json.dumps(
-            tax_response.get("TransactionTaxes")
-        ),
-        get_metadata_key("tax_transaction"): json.dumps(
-            tax_response.get("Transaction")
-        ),
-    }
+    tax_metadata = build_metadata(tax_response)
     order.store_value_in_metadata(items=tax_metadata)
     order.save()
 

--- a/excise/tests/conftest.py
+++ b/excise/tests/conftest.py
@@ -1,11 +1,12 @@
 import pytest
-from django.db import connection
 from django.core.management.color import no_style
+from django.db import connection
+from saleor.account.models import Address
 from saleor.checkout.models import CheckoutLine
 from saleor.plugins.models import PluginConfiguration
-from saleor.warehouse.models import Warehouse
 from saleor.product.models import ProductType
-from saleor.account.models import Address
+from saleor.warehouse.models import Warehouse
+
 from ..plugin import AvataxExcisePlugin
 
 

--- a/excise/tests/test_avatax_excise.py
+++ b/excise/tests/test_avatax_excise.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import asdict
 from decimal import Decimal
 from unittest.mock import Mock, patch
 from urllib.parse import urljoin
@@ -8,22 +9,17 @@ from django.core.exceptions import ValidationError
 from django.test import override_settings
 from prices import Money, TaxedMoney
 from requests import RequestException
-from dataclasses import asdict
-
-from saleor.checkout.utils import add_variant_to_checkout
 from saleor.checkout.fetch import fetch_checkout_info, fetch_checkout_lines
+from saleor.checkout.utils import add_variant_to_checkout
 from saleor.core.prices import quantize_price
 from saleor.core.taxes import TaxError
-from saleor.product.models import ProductVariant
 from saleor.plugins.manager import get_plugins_manager
 from saleor.plugins.models import PluginConfiguration
+from saleor.product.models import ProductVariant
+
 from ..plugin import AvataxExcisePlugin
-from ..utils import (
-    AvataxConfiguration,
-    api_post_request,
-    get_metadata_key,
-    get_order_request_data,
-)
+from ..utils import (AvataxConfiguration, api_post_request, get_metadata_key,
+                     get_order_request_data)
 
 
 @patch("saleor.plugins.avatax.excise.plugin.api_get_request")
@@ -173,12 +169,8 @@ def test_calculate_checkout_line_total(
         get_metadata_key("itemized_taxes")
     )
 
-    sales_tax = checkout_with_item.metadata.get(
-        get_metadata_key("sales_tax")
-    )
-    other_tax = checkout_with_item.metadata.get(
-        get_metadata_key("other_tax")
-    )
+    sales_tax = checkout_with_item.metadata.get(get_metadata_key("sales_tax"))
+    other_tax = checkout_with_item.metadata.get(get_metadata_key("other_tax"))
 
     assert taxes_metadata is not None
     assert len(taxes_metadata) > 0
@@ -303,12 +295,8 @@ def test_calculate_checkout_shipping(
         get_metadata_key("itemized_taxes")
     )
 
-    sales_tax = checkout_with_item.metadata.get(
-        get_metadata_key("sales_tax")
-    )
-    other_tax = checkout_with_item.metadata.get(
-        get_metadata_key("other_tax")
-    )
+    sales_tax = checkout_with_item.metadata.get(get_metadata_key("sales_tax"))
+    other_tax = checkout_with_item.metadata.get(get_metadata_key("other_tax"))
 
     assert taxes_metadata is not None
     assert len(taxes_metadata) > 0
@@ -342,8 +330,7 @@ def test_calculate_checkout_total_invalid_checkout(
     checkout_info = fetch_checkout_info(checkout_with_item, [], [], manager)
     total = manager.calculate_checkout_total(checkout_info, [], [], [])
     assert total == TaxedMoney(
-        net=Money("0.00", "USD"),
-        gross=Money("0.00", "USD")
+        net=Money("0.00", "USD"), gross=Money("0.00", "USD")
     )
 
 
@@ -541,7 +528,7 @@ def test_api_post_request_handles_json_errors(product, monkeypatch):
     config = AvataxConfiguration(
         username_or_account="test",
         password_or_license="test",
-        use_sandbox=False
+        use_sandbox=False,
     )
     url = "https://www.avatax.api.com/some-get-path"
 
@@ -579,12 +566,10 @@ def test_order_created_calls_task(
 
     base_url = "https://excisesbx.avalara.com/"
     transaction_url = urljoin(
-        base_url,
-        "api/v1/AvaTaxExcise/transactions/create"
+        base_url, "api/v1/AvaTaxExcise/transactions/create"
     )
     commit_url = urljoin(
-        base_url,
-        "api/v1/AvaTaxExcise/transactions/{}/commit"
+        base_url, "api/v1/AvaTaxExcise/transactions/{}/commit"
     )
     data = get_order_request_data(order_with_lines)
     conf = {data["name"]: data["value"] for data in config.configuration}
@@ -602,7 +587,7 @@ def test_order_created_calls_task(
         asdict(data),
         configuration,
         order_with_lines.id,
-        commit_url
+        commit_url,
     )
 
 

--- a/excise/tests/test_avatax_excise.py
+++ b/excise/tests/test_avatax_excise.py
@@ -173,8 +173,17 @@ def test_calculate_checkout_line_total(
         get_metadata_key("itemized_taxes")
     )
 
+    sales_tax = checkout_with_item.metadata.get(
+        get_metadata_key("sales_tax")
+    )
+    other_tax = checkout_with_item.metadata.get(
+        get_metadata_key("other_tax")
+    )
+
     assert taxes_metadata is not None
     assert len(taxes_metadata) > 0
+    assert sales_tax >= 0
+    assert other_tax >= 0
 
 
 @pytest.mark.vcr
@@ -294,8 +303,17 @@ def test_calculate_checkout_shipping(
         get_metadata_key("itemized_taxes")
     )
 
+    sales_tax = checkout_with_item.metadata.get(
+        get_metadata_key("sales_tax")
+    )
+    other_tax = checkout_with_item.metadata.get(
+        get_metadata_key("other_tax")
+    )
+
     assert taxes_metadata is not None
     assert len(taxes_metadata) > 0
+    assert sales_tax >= 0
+    assert other_tax >= 0
 
 
 @patch("saleor.plugins.avatax.plugin.AvataxPlugin._skip_plugin")

--- a/excise/tests/test_tasks.py
+++ b/excise/tests/test_tasks.py
@@ -1,16 +1,13 @@
-import pytest
+from dataclasses import asdict
 from decimal import Decimal
 from urllib.parse import urljoin
-from dataclasses import asdict
-from saleor.order import OrderEvents
-from ..utils import (
-    AvataxConfiguration,
-    get_api_url,
-    get_metadata_key,
-    get_order_request_data
-)
-from ..tasks import api_post_request_task
 
+import pytest
+from saleor.order import OrderEvents
+
+from ..tasks import api_post_request_task
+from ..utils import (AvataxConfiguration, get_api_url, get_metadata_key,
+                     get_order_request_data)
 
 config = AvataxConfiguration(
     username_or_account="test",
@@ -71,11 +68,11 @@ def test_api_post_request_task_with_invalid_productcodes(
         asdict(request_data),
         asdict(config),
         order_with_lines.id,
-        commit_url
+        commit_url,
     )
 
     assert response is None
-    msg = "Product \"FAKEPROD\" does not exist"
+    msg = 'Product "FAKEPROD" does not exist'
 
     assert order_with_lines.events.count() == 1
     event = order_with_lines.events.get()
@@ -133,7 +130,7 @@ def test_api_post_request_task_with_valid_productcodes(
         asdict(request_data),
         asdict(config),
         order_with_lines.id,
-        commit_url
+        commit_url,
     )
 
     expected_event_msg = (
@@ -150,12 +147,8 @@ def test_api_post_request_task_with_valid_productcodes(
         get_metadata_key("itemized_taxes")
     )
 
-    sales_tax = order_with_lines.metadata.get(
-        get_metadata_key("sales_tax")
-    )
-    other_tax = order_with_lines.metadata.get(
-        get_metadata_key("other_tax")
-    )
+    sales_tax = order_with_lines.metadata.get(get_metadata_key("sales_tax"))
+    other_tax = order_with_lines.metadata.get(get_metadata_key("other_tax"))
 
     assert taxes_metadata is not None
     assert len(taxes_metadata) > 0
@@ -163,13 +156,13 @@ def test_api_post_request_task_with_valid_productcodes(
     assert other_tax >= 0
 
 
-def test_api_post_request_task_order_doesnt_have_any_lines_with_taxes_to_calculate(
+def test_api_request_task_order_doesnt_have_any_lines_with_taxes_to_calculate(
     order_with_lines, shipping_zone, monkeypatch
 ):
     mock_api_post_request = {"error": {"message": "Wrong credentials"}}
     monkeypatch.setattr(
         "saleor.plugins.avatax.tasks.api_post_request",
-        lambda *_: mock_api_post_request
+        lambda *_: mock_api_post_request,
     )
 
     request_data = {}

--- a/excise/tests/test_tasks.py
+++ b/excise/tests/test_tasks.py
@@ -150,8 +150,17 @@ def test_api_post_request_task_with_valid_productcodes(
         get_metadata_key("itemized_taxes")
     )
 
+    sales_tax = order_with_lines.metadata.get(
+        get_metadata_key("sales_tax")
+    )
+    other_tax = order_with_lines.metadata.get(
+        get_metadata_key("other_tax")
+    )
+
     assert taxes_metadata is not None
     assert len(taxes_metadata) > 0
+    assert sales_tax >= 0
+    assert other_tax >= 0
 
 
 def test_api_post_request_task_order_doesnt_have_any_lines_with_taxes_to_calculate(

--- a/excise/utils.py
+++ b/excise/utils.py
@@ -37,6 +37,11 @@ logger = logging.getLogger(__name__)
 TRANSACTION_TYPE = "DIRECT"
 SHIPPING_UNIT_OF_MEASURE = "EA"
 
+# The identifiers for tax types that we would need to group
+# for the tax breakdown
+SALES_TAX = "S"
+USE_TAX = "U"
+
 
 @dataclass
 class AvataxConfiguration:
@@ -607,14 +612,14 @@ def process_checkout_metadata(
 
 def get_sales_tax(taxes_data: Dict[str, Dict]) -> int:
     """
-    Build the sales tax amount where tax type is either "S" or "U"
+    Build the sales tax amount where tax type is either SALES_TAX or USE_TAX
     """
     return sum(
         map(
             lambda tax_data: tax_data.get("TaxAmount", 0),
             filter(
-                lambda tax_data: tax_data.get("TaxType") == "S"
-                or tax_data.get("TaxType") == "U",
+                lambda tax_data: tax_data.get("TaxType") == SALES_TAX
+                or tax_data.get("TaxType") == USE_TAX,
                 taxes_data.get("TransactionTaxes", []),
             ),
         )
@@ -623,15 +628,15 @@ def get_sales_tax(taxes_data: Dict[str, Dict]) -> int:
 
 def get_other_tax(taxes_data: Dict[str, Dict]) -> int:
     """
-    Building the remaining tax amount after getting the sales tax,
-    i.e. where the tax type is neither "S" nor "U"
+    Building the remaining tax amount after getting the total sales tax,
+    i.e. where the tax type is neither SALES_TAX nor USE_TAX
     """
     return sum(
         map(
             lambda tax_data: tax_data.get("TaxAmount", 0),
             filter(
-                lambda tax_data: tax_data.get("TaxType") != "S"
-                and tax_data.get("TaxType") != "U",
+                lambda tax_data: tax_data.get("TaxType") != SALES_TAX
+                and tax_data.get("TaxType") != USE_TAX,
                 taxes_data.get("TransactionTaxes", []),
             ),
         )


### PR DESCRIPTION
Changes:

- Added extra tax fields, i.e, sales_tax and other_tax, which is just breakdown of the tax that is returned by the plugin API. [Commit #1](https://github.com/saleor/saleor-plugin-avatax-excise/commit/7dbedd88d6ad8e2316cf8c8be5f37a0620b4cbf2)
- Made changes to accomodate the latest 3.0.0-b.7 release. [Commit #2](https://github.com/saleor/saleor-plugin-avatax-excise/commit/5b5f5d835e9b7041d3efe6aa771179b3c9985b05)
- Formatted the code through black and isort. Fixed the flake8 warnings. [Commit #3](https://github.com/saleor/saleor-plugin-avatax-excise/commit/65eaa699c607cb4b92a540d5cbf3f8060f648d16)