### PR TITLE
fix: do not refresh entire checkout object

### DIFF
--- a/excise/utils.py
+++ b/excise/utils.py
@@ -608,7 +608,7 @@ def process_checkout_metadata(
     metadata = build_metadata(taxes_data)
 
     if force_refresh or metadata_requires_update(metadata, data_cache_key):
-        checkout.refresh_from_db()
+        checkout.refresh_from_db(fields=['metadata'])
         checkout.store_value_in_metadata(items=metadata)
         checkout.save()
         cache.set(data_cache_key, metadata, cache_time)


### PR DESCRIPTION
This fixes the error which occurs while changing the address while plugin is enabled. 

This has potential to be a bigger issue than this, as we were always reloading the state from DB. So any changes made outside this context always gets overridden!

This can not be solved with just providing the metadata field in the save, because we receive the checkout object by reference, and any modification done here, propagates to other parts of the system as well.