### PR TITLE
Adjust order and checkout methods to new data structures

### DIFF
--- a/excise/tests/test_avatax_excise.py
+++ b/excise/tests/test_avatax_excise.py
@@ -159,8 +159,11 @@ def test_calculate_checkout_line_total(
         checkout_with_item.shipping_address,
         discounts,
     )
-    total = quantize_price(total, total.currency)
-    assert total == TaxedMoney(
+    price_with_discounts = total.price_with_discounts
+    price_with_discounts = quantize_price(
+        price_with_discounts, price_with_discounts.currency
+    )
+    assert price_with_discounts == TaxedMoney(
         net=Money(expected_net, "USD"), gross=Money(expected_gross, "USD")
     )
 

--- a/excise/utils.py
+++ b/excise/utils.py
@@ -369,10 +369,11 @@ def get_checkout_lines_data(
     if shipping_address is None:
         raise TaxError("Shipping address required for ATE tax calculation")
     for line_info in lines_info:
+        prices_data = base_calculations.base_checkout_line_total(
+            line_info, channel, discounts
+        )
         append_line_to_data(
-            amount=base_calculations.base_checkout_line_total(
-                line_info, channel, discounts
-            ).net.amount,
+            amount=prices_data.price_with_discounts.net.amount,
             data=data,
             line_id=line_info.line.id,
             quantity=line_info.line.quantity,
@@ -497,11 +498,11 @@ def get_cached_response_or_fetch(
     Fetch new data in other cases.
     """
     data_cache_key = CACHE_KEY + token_in_cache
-    if taxes_need_new_fetch(data, token_in_cache) or force_refresh:
+    cached_data = cache.get(data_cache_key)
+    if taxes_need_new_fetch(data, cached_data) or force_refresh:
         response = _fetch_new_taxes_data(data, data_cache_key, config)
     else:
-        _, response = cache.get(data_cache_key)
-
+        _, response = cached_data
     return response
 
 


### PR DESCRIPTION
Refactor `calculate_checkout_line_total` and `calculate_checkout_line_unit_price` to use `CheckoutTaxedPricesData`.
Refactor `calculate_order_line_total` to use `OrderTaxedPricesData`.