### PR TITLE
Adjust excise plugin for order migration from id to uuid

### DIFF
--- a/excise/tasks.py
+++ b/excise/tasks.py
@@ -51,10 +51,10 @@ def api_post_request_task(
     msg = ""
     if not tax_response:
         msg = (
-            f"Empty response received from Excise API, order: {order.token}"
+            f"Empty response received from Excise API, order: {order.id}"
         )
         logger.warning(
-            "Empty response received from Excise API, Order: %s", order.token
+            "Empty response received from Excise API, Order: %s", order.id
         )
         external_notification_event(
             order=order, user=None, app=None, message=msg, parameters=None
@@ -68,7 +68,7 @@ def api_post_request_task(
         msg = f"Unable to send order to Avatax Excise. {error_msg}"
         logger.warning(
             "Unable to send order %s to Avatax Excise. Response %s",
-            order.token,
+            order.id,
             tax_response,
         )
         external_notification_event(
@@ -76,7 +76,7 @@ def api_post_request_task(
         )
         return
     else:
-        msg = f"Order sent to Avatax Excise. Order ID: {order.token}"
+        msg = f"Order sent to Avatax Excise. Order ID: {order.id}"
         user_tran_id = tax_response.get("UserTranId")
         if config.autocommit and commit_url and user_tran_id:
             commit_url = commit_url.format(user_tran_id)
@@ -85,7 +85,7 @@ def api_post_request_task(
                 {},
                 config,
             )
-            msg = f"Order committed to Avatax Excise. Order ID: {order.token}"
+            msg = f"Order committed to Avatax Excise. Order ID: {order.id}"
             commit_status = commit_response.get("Status", "")
             if not commit_response or "Error" in commit_status:
                 errors = commit_response.get("TransactionErrors", [])
@@ -95,7 +95,7 @@ def api_post_request_task(
                 msg = f"Unable to commit order to Avatax Excise. {error_msg}"
                 logger.warning(
                     "Unable to commit order %s to Avatax Excise. Response %s",
-                    order.token,
+                    order.id,
                     commit_response,
                 )
 

--- a/excise/tests/test_tasks.py
+++ b/excise/tests/test_tasks.py
@@ -135,7 +135,7 @@ def test_api_post_request_task_with_valid_productcodes(
 
     expected_event_msg = (
         "Order committed to Avatax Excise. "
-        f"Order ID: {order_with_lines.token}"
+        f"Order ID: {order_with_lines.id}"
     )
     assert order_with_lines.events.count() == 1
     event = order_with_lines.events.get()

--- a/excise/utils.py
+++ b/excise/utils.py
@@ -541,7 +541,7 @@ def get_order_tax_data(
     data = get_order_request_data(order)
 
     response = get_cached_response_or_fetch(
-        data, "order_%s" % order.token, config, force_refresh
+        data, "order_%s" % order.id, config, force_refresh
     )
     if response.get("Status") != "Success":
         transaction_errors = response.get("TransactionErrors")
@@ -555,7 +555,7 @@ def get_order_tax_data(
                 logger.warning(
                     "Unable to calculate taxes for order %s, error_code: %s, "
                     "error_msg: %s",
-                    order.token,
+                    order.id,
                     error_code,
                     error_message,
                 )


### PR DESCRIPTION
Replace `order.token` with `order.id`.

Changes for https://github.com/saleor/saleor/pull/9324