### PR TITLE
Adjust plugin for new order id

### DIFF
--- a/excise/tests/cassettes/test_avatax_excise/test_calculate_checkout_shipping.yaml
+++ b/excise/tests/cassettes/test_avatax_excise/test_calculate_checkout_shipping.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-01", "InvoiceDate": "2021-07-01", "TitleTransferCode":
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
       "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 1,
-      "ProductCode": "123", "UnitPrice": "30.00", "UnitOfMeasure": null, "BilledUnits":
-      "3", "LineAmount": "30.00", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
+      "ProductCode": "123", "UnitPrice": "15.00", "UnitOfMeasure": null, "BilledUnits":
+      "3", "LineAmount": "15.00", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": null, "DestinationCountryCode":
       "USA", "DestinationJurisdiction": "VA", "DestinationAddress1": "1100 Congress
       Ave", "DestinationAddress2": "", "DestinationCounty": "", "DestinationCity":
@@ -32,7 +32,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
@@ -42,7 +42,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -50,28 +50,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1ZXW+jOBR9H2n+A+K5iYC0SWbeKKEps2mSDbS7q9U8OOCklghkDUSNqv73tc1H
-        bExINvvQrrZSpVQ+x9fXx8e+Bl6/flEU9TGB2MMgcgL1u6Le+N9uhkGgd/qgv+pc+/6qswwMvdMb
-        LvtwqS/1/nKlXrGOVadrvX+t6QMjb3ZTkGYJjeVmvg+TpKAvYJrhyIoDSDCtCBGnIPTAi7mJsygl
-        7Xp3oB2iJ8BPURwRAqQB/6SAorzmPxInD8KIP68qjgv/ymDkQ5apftXUd4IiKIJOtIuRD2XAokPg
-        fTEL9dE11QP4I8MoCRCLSdEnHpzEPgjrjBudY8xxHGR+aoEUrmO8pyp1NS5h8IKi9QTuYMjE9fjo
-        BPT2W5aTyzUvSKyyfVxrd7NlWkDT2dTmUAuEfhYCJithOBFzxlwcjobIU7zuaZqY568ZiFKUNk2B
-        W2nDEBD7BW62dMxivCk3ngtCmBDOLUhgFcEYdsWRJ2TJogROs80SYhqiNuMRTHyMtoflUYiInq14
-        5u9KR3lyFmNn6vCqWhnGxDv7fKlHfEJEPOrdIleLh5j/S4eYluc88eKW2hQ9b9Ucebv61+Y2Ppi5
-        +wOyOhf723K8D+JvXbvE31rXGL67v4mIfxT2XjjW/cNsOvrP2rv3wew9G7vzy+3tej8+iL21wYX2
-        1t7d3u7cthxzUnO4Ys0I8k4+pz8/pRuMjXGMG68wx64nrEc5emf47UatYQ/kZgXWDJ7HW7be0VqZ
-        YbRGkYKiVYw3zAJKllCAiEcIeQuPkv+U9JCoEpJtoxjd+mjMt8VcfwM4IiHVtv1otMpBCIUC9a6c
-        RpxKJ7Z8y6Yn0C0Kw9lqAgKSc5O3uK1byG05Y3MhEMwwhZioB2tM3egJvNsQRoEX11gC5TFC6RyT
-        XOmRRrdfPVcYUAoVotfV6j1nqwcIkgzn627+IoXm9q5Bo2tSiJIhhbOteyEcFbParVKqdxii9XNa
-        Hk9Cz6MbjmC5Q9vO4orUdiaLkfZSCgWYK6EukP+8iYl9Zco8TsgBUCZi9Ayj38BqnGYOmUGAyV7U
-        mR/IXUGx4mhNWxRzB4/zjWPhEN7GuNk73CY+ISDHPKFiPaYsJc9o05PjnRKVozYqy+Hnyyt3kjXm
-        OS1C04J1QmFKOSFtFUXWlEFtYlLCKRUpp1E+CpyvG8eWBWNgi1JsfhDXxGqi1MU6GkZWq0TRcUzU
-        qonRfFLlGC9WCy7LU+ItCtH3KyOQgqZ6MUKJTyNw1yqthN8q4qt0SLhb6CPxSlq7O4teP4vfUMWP
-        l1ipbP2zEktubHcL2xnfewLrzPrZWraqWi0zxe0p1DedFcvPAvdZkT4r0mdF+v9UJPcZbbfC09yp
-        spT/U1aOw1eA8vAkGWy2INrnT7S93qBsJ6c6/RxQPEVWh6Zqr1aQrMEOjvJ3EqqhGXpHG3Q03dO0
-        7+yvIhdV6BzqXQZDMtW6BKqHUuJSWuxWsHrEHtmup/JzKt9NFWs0cha2VWNQgdnGfSBB5GGKbxvs
-        mbb6riEAR8pIzlhAGp8sTRnj8C5GWEGVb7zkQ07RNf8+A4MnEGbiTNw4wz5090kKNwJAVnqDUu6D
-        D9jB6tBQzR2g77VkLdnroGIhxTmXxjtYLr8FcQke0vv65e1v6ntH6sIaAAA=
+        H4sIAAAAAAAEAO1XXU/bMBR9n8R/sPJcSprC2PpW0gKdClRNiiZNPHjJbWsptTsnqVYh/vv8kRQn
+        TluY9jQhIYHuOb4fx/G93OeTTwg5Icd0FDs9dO5efD3vfmkpa5DhLE+F1RlyzniK5iynsaPBKWQ5
+        pz6LQRBOO9oYsgwnIf7dXwlmJgC37bZ2EVIcZYRRgYP0+uPJgnQciUkEoWf9S+YCv3KgEagsdTRl
+        VyeKLJzTjut2nRp4B2mKFwq/ZyiIgGJOGOIQMR7rktoImflt19BDg9F06IfogZMFod9yTtKYKLiH
+        HvuF2ZdV8q0M30OzoI8GkGaEYkmzjhiYdS4kWQIqhTlwbR4Mg1CcyYCvilMTzuI8ynycwYLxbQ9d
+        eCiAJAE+ioXSaDifgwi3gYFgCMP5mXd55rmeh1y3p37QBHi61qSrPCVUSKOrRf4SEzqGhVCppt8Y
+        NpCMqNTd8TnJSIQTg2MINxYO5e1o7EX+sq9YEIpbrR817t24+eYQLQMe0Q0jETRBVyRJHuZjHBO6
+        uM9XP4HLKhyTUqpafEIdr1uBrxKgcchqrAplRkk24SIDGf2i7br1DCCWFFlet+3WTz7M7wCnOVd+
+        b8bjimtZ0+4tWb6vOZDFMpM3aCXl55yL97KVwCwYVDDr49WkfgPJ/Iol67GJpDxtrRQKkGhoSqLl
+        ipXto0KZsFS0jTIRr+t5nxtYjWVqqB/HXHzKHXWBogcgn9GFtKD+BvbzvX3uCF8z3nzZza+4ScA9
+        vaBBxbpPW0qTcUhPg3dMVIPaqKyBv11e+5Ctsck5IHSAEziisKQckXbnxdZUQYfElIRjKkpOo3wS
+        eLtuBtsWTIEHlFL1ybFREauJUhdrrxtbrRIl+7GqVk2M5k6lMVOsA7gtT4kfUGiWAhdDEZcNvoRe
+        dqTD48bbP26sZv++cRP2v19Ph6Ob2/Bvpk5ldgz92wqhnwhVxDsDm1l9I9UhI/5j++dT5thseGe3
+        /2jPH+35oz3/n+05WJL1WrTP1x6t/3hqGUuDWgLLJiUirNaYbvVm2O1elnbRPSORUrG6DMuQTmVP
+        Ut+N2JFO3fNT7zIsN6Uduej2b6Fe55CIUuolOtZyJ1G53jlmTcbyqXC1flYZUkD1MO+EEztMsXtD
+        anblKjwF6UPIW+7g7m4hqdyCYxr1pg/xI07yasiA5TyCYJtmsFKAtOuhapx8PXfy6eUPHSzisXAQ
+        AAA=
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -80,7 +75,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1241'
+      - '914'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -91,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jul 2021 16:55:00 GMT
+      - Wed, 27 Apr 2022 13:28:10 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -100,10 +95,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/cassettes/test_avatax_excise/test_calculate_checkout_total_excise_data[20-38.76-False-202000000-172-destination0-metadata0].yaml
+++ b/excise/tests/cassettes/test_avatax_excise/test_calculate_checkout_total_excise_data[20-38.76-False-202000000-172-destination0-metadata0].yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-01", "InvoiceDate": "2021-07-01", "TitleTransferCode":
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
       "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 1,
-      "ProductCode": "202000000", "UnitPrice": "10.00", "UnitOfMeasure": null, "BilledUnits":
+      "ProductCode": "202000000", "UnitPrice": "10.00", "UnitOfMeasure": "PAC", "BilledUnits":
       "1", "LineAmount": "10.00", "AlternateUnitPrice": "1.000", "TaxIncluded": false,
       "UnitQuantity": 25, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
       "USA", "DestinationJurisdiction": "VA", "DestinationAddress1": "2000 Main Street",
@@ -32,17 +32,17 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '2235'
+      - '2236'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -50,32 +50,32 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1ZXW+jOBR9H2n+A+K5iYB8dt4oSTOM0iYbmO6uVvPggpMiEcgaiBqN+t/n2nzE
-        5itp56FZbatKrTjH1/bxub42/Pz8SZLk7xEmNkGB6cpfJBn1lZ6Kh24HrwdKp9/X+p1rbTjoDNHj
-        ej0eKNi57slXrGHRqK8O+4o6GqaPrRjFSURjWYnj4CjK6CscJyQwQhcDpmQhwhj5NnrWt2ESxPBc
-        HXfzODR8hJzYCwNgYBrxHwpI0s/0T4WTRmHEH1cFx8L/JjhwMBuqelXXdu4FWATNYB96Dq4CBu2C
-        HLJpyN8tXT6C3xLiRa7HYlL0gQfnoYP8MuN+cT/lOEsSuokTGyjGm5AcqFBdhRsyevaCzRzvsc/0
-        tXWbbw2wfdixcdmLG90wFhy4gpgFqv9VQqzkMc5Aw5zpKw42kO8kPmIaA8UMmE+WYr80BhutpuQ/
-        Av5HgoLYi+mM1NKMjms/6qo9AZo+4+2Odpx1es91OsFrTAh2ayAL+TiC5jcowkX08aA7HHCrAasb
-        RPg+2T5iQgNw7WlGpG7F7gPyEyaLpmRT4zuCGIh4IbOW1lPVwWBcRWEkMxImO8YajIajKiX3qOg1
-        KuoERw7xdkdHSTS/sGR4G0QkCC11pDsUJGtwckIwkdjkpSWB+fGLmIBWgXNIPTvhJxt48WJ9h1EE
-        zSk8m8/5KYIxaJJmMgvGSTM9TwXdsM0H3o75mmdNb+QUebn67SzWLiyLB+rv5HB9BlsNuTtrztzS
-        ZvK6xFX6vZakLU/hmLRddXR2ztYmpiamfVtiNiQE3QYl2NMgFR7M1cy8N/WzrF/ytnEJ1u5dmLWH
-        I3HLe527DdO+EHerbSWp0d1Qz97b3SDh35m5V6bx9W5xP/nPmrt/YeZezKzl281t2d8uxNzK6G3m
-        Vq/fe+teTg1Tn5f8LRkLQN7J5fTPj8oNZEpISGqvIE3XC9Yi770zvh7IJewOrkZow+BluGOrHWyk
-        BfE2XiB5wTokW2YAKYkoAOIBIX3Co/CfFB8HKvmQNJLWLffGXJvN9U9EAggpt2Wj1ioHEDIFyk05
-        jTiVTiR8S8oDdOP5/mI9Ry6Muc5bXOJmcpeuMEDQ/RgTUA+XmDWnetqjjwPXDktcgUKPzekhG0ZL
-        U7C2N54lXkCyeWGXUqLStejksTwjcFmuDartc7gSa2p8bYwFY6/ydYFOF+l4ACxP/pZgb/MU55ue
-        0LIxkQFLnd+2wxektp1ejHSoDCEDU9Xklec8bUNIiyplGUawsRRG6WnasIZVO80U0l2XQI6rFFbh
-        /CEZYbChTyR9j5v5WlM4j+xCUu9GbnM4ISDHPKFiOWZVSp7RpifHOyUqR61VlsN5eWkSwzUYNk4r
-        JhjHJ9pUJeY5LTrTKnhCYEo5oWwRpSopg9q0pIRTIlJOrXoUOFs2jlzVi4EtQrHpYVLSqo5S1qox
-        TFWsHPWaMVGqOkb9PpVivFYteFWeHG9RiL5kmqAYNVchI4nicAsVD0MFoWMYq93+sJGh1dUYgdED
-        xvWgO9IE53uRQ0fLHQuVHH4piHwlT7cja4cdTzxSl87+Ylqdxa85hzQfEoSq8/pDApw5b1dTc/bV
-        Flhn1v7WeirU/9dV0o9S+lH7PmrfR+3739Q+68nb7YTb6KmilP6T143jZ8h864QRbHcoOKQ38l4v
-        f4NHCwD9HpndgostU56u1xjWYI8n6RsVWo/VjjLqKKqtKF/Yb0HOatA51NsE+zDVsgSy7cVgUlrq
-        1rh4RTCZWrbMzyl/s5at0cRcTY0SgwrM8vYOglS7yT6usjv58cOqgDRUkZSxwrQDWJs8yPFVkrCE
-        Mv/wLZ+SpYZvbgVqhQlxsHWIYrwVAFjqrRdzn5zRHhebhqzvEX0tVxWTvc3KVlKcc+68o+fSQxA3
-        wOPwPn96+QW+cH5hRB8AAA==
+        H4sIAAAAAAAEAO1ZW2+jOBh9H2n+A+K5iYDc2nmjJE2ZbZtsYLq7Ws2DC06KRCBrIGo06n/fz+Zm
+        c0sv85DZbVWpFef4s338HX82/Pj8SZLkbxEmNkGB6cpfJFmZ4KE7mFz0tLGi9IYThHto8KD0nKE7
+        dNcDPHa1tXzGGhaNhsroYjgYp0+tGMVJRENZiePgKMrYKxwnJDBCFwOmZBHCGPk2etK3YRLE8Fw9
+        70/GZfQIObEXBsDANOLfFJCkH+mfGieNwojfzwqOhf9JcOBgNlL1rKntjRdgETSDfeg5uA4YtAty
+        yKYhf7N0uQS/JsSLXI/FpOg9D96EDvKrjLvF3YzjLEnoJk5soBhvQnKgQvUVbsjoyQs2N3iPfaav
+        rdt8a4Dtw46Ny15c6oax4MAVxCxQ/c8KYiUPcQYa5lxfcbCBfCfxEdMYKGbA0mQp9ktjsNFqSv4j
+        4L8nKIi9mM5IrcyoXPtJXx0I0OwJb3e046zTO67TKV5jQrDbAFnIxxE0v0QRLqKfj/rjEbcasLpB
+        hO+S7QMmNADXnhoizVbs3iM/YbJoSjY1viOIgYgXstTSBqo6Gp3XURjJnITJjrFGk/GkTslzVMw1
+        KuoURw7xdmVGSdRfWDK8DSIShJZ60i0KkjVkckIwkdjkpSWB+fGLmIBWgXNIc3bKTzbw4sX6FqMI
+        mlN4hxx+ipAY1KSZzELipE7PraAbtnnPp2O+5lnTSzlFns/e7WLtxFw8Ut/j4WYHWy3enbc7t7KZ
+        vM64ynDQYdrqFErT9tXJiz3baExNtP1PMWaLc+h+KcHmB565N1dz887UX+SRigmMd3ighGYMgCnl
+        jX+ePwYn5o/xRFye11nEMO0TsYjaVddaLQJF8ZexCGj9V+aQlWlc3y7upv9JhwxPzCGLubV8u0Ms
+        ++uJOESZvM0h6sWv4hBrOTNM/aZiEslYAHKCVqF/vtcuVDNCQtJ4o2q7LbEWefDe+cVIrmC3cNND
+        GwYvwx1LmWAjLYi38QLJC9Yh2bIskpKIAiAsENInPAr/SXE5UMkH50lav9obS/1Mhz8QCSCk3GVp
+        rVMOIGQKVJtyGnEqHdk1OvYNgC4931+sb5ALY25KUM79mdyVGxkQdD/GBNTDFWZDGtMefRy4dljh
+        ChR6C0jvDDBa6uPG3niWeJ/K5oVdSokqt7ymW8ZS/615Rg1MozZUblPRRvWecrgWa2Zct8aCEdT5
+        ukCny1mefKsyXRHsbR7jfI8VWrZuB4ClHukqKAWpq7CIkQ61IWRgqpq88pzHbQgGqlOWYQTbU5FS
+        A00bN7Aap5lCuusS2A1UCqtwZpKMMNjQJ5K+x+18rS2cR3Yhac5bbhs5IiDHPKJiNWZdSp7RpSfH
+        OyYqR21UlsN5eand4f4PW6wVE4zjI23qEvOcDp1p0T0iMKUcUbaIUpeUQV1aUsIxESmnUT0KvFg2
+        jlzXi4EdQrHpYVLRqolS1ao1TF2sHPXaMVGqJkbzPpVivFYdeF2eHO9QiJ6/pihG7fXKSKI43EJt
+        xFBr6BjO1f5w3MrQmqqRwBgA42LUn2hC5nuRQ0fLnUKVHH4uiHzNT7cja4cdTzzBV64aoq1exG84
+        sbQfJ4Sq8/rjBJxcr1Yzc35tC6wXnhI662l7FT9aST9K6Uft+6h9H7Xvf1P7rEdvtxPurceKUvpP
+        XjfKz6/51gkj2O5QcEjv7oNB/taRFgD6ITa7LxdbpjxbrzGswR5P0xc4tB5rPWXY0ya2onxhvwU5
+        q0EvoV4l2OffRRQj9mJIUlrq1rh4mTCdWbbMzyl/kZet0dRczYwKgwrMfHsLQerdZF+V2e29/KIs
+        IC1VJGWsMO0A1iYPUr65EpZQ5h++5RO61PI6qkCtMCEOtg5RjLcCAEu99WLuWzva42LTkPU9om8B
+        62Kyl2fZSopzzjOvzLn0EMQNsBze50/P/wJGAUP/PCAAAA==
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -84,7 +84,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1441'
+      - '1459'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jul 2021 16:55:02 GMT
+      - Wed, 27 Apr 2022 13:28:08 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -104,10 +104,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/cassettes/test_avatax_excise/test_calculate_checkout_total_excise_data[20.00-24.95-False-202015500-170-destination1-metadata1].yaml
+++ b/excise/tests/cassettes/test_avatax_excise/test_calculate_checkout_total_excise_data[20.00-24.95-False-202015500-170-destination1-metadata1].yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-01", "InvoiceDate": "2021-07-01", "TitleTransferCode":
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
       "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 1,
-      "ProductCode": "202015500", "UnitPrice": "10.00", "UnitOfMeasure": null, "BilledUnits":
+      "ProductCode": "202015500", "UnitPrice": "10.00", "UnitOfMeasure": "PAC", "BilledUnits":
       "1", "LineAmount": "10.00", "AlternateUnitPrice": "1.000", "TaxIncluded": false,
       "UnitQuantity": 18, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
       "USA", "DestinationJurisdiction": "AZ", "DestinationAddress1": "2000 Main Street",
@@ -31,17 +31,17 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '2225'
+      - '2226'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -49,32 +49,32 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1ZW0/jOBh9H2n+gxXtw65EUS60lHlYKaSF6apQtg3s7qzmwSRusZQmHSepqEb8
-        9/3sXGrnVph5gJVASKCc48/28XeL8/3jB4S025gwl+Fw4mufkHbmGwNLHw571uDM7530idXDS2/Q
-        G/TxUMcnxBjc32tHYmA56MQYnOjG0MgeLxKcpDG3tUg9j8RxTp+TJGWhE/kEMD03ESU4cPGjvY7S
-        MOGmjs/6e+sx9hIahUAg3OC/HEDoe/anxsmMCOLXo5KzIN9SEnpErNQ4aho7pSFRwUm4jahH6oDD
-        p2C7fBfa7cLW9uAfKaOxT4VNjtpfJHAaeTioMq5n12OJc8MiP/USBydkFbEd1+lYl5aMH2m4mpIt
-        CYS8ru3KowF2dxuxLnd2bjvOTALnYLNE7b8ryCK9T3LQmVzacwl2cOClARYaA2USCjdx1Hm5DbFa
-        0xjq2Y+C/5niMKEJ35ExrGypPHvr+MxUkPEjWW/4xPmk19KkI7IkjBG/AVrggMQw/BzHpDSuCDmF
-        sw1jcp2u7wnjw6XRPBwyVyX+HQ5SIYqpm7rR7+u6PA3YwIxGwrFMyzCs4VkdhXVcsijdCFb/1Dyp
-        UwoPBcJAPZYRiT1GN3t/Qjy4CHLoCjMEptGvY+w9/IZ66Hdkoel9jDaEIYPLj2ATmAbohsFmAf4F
-        FOjL55qCfKG3y9x4JCsQ0mS2vCI4TpnY/dj5LO8bfIWHba78rQyJ0C+Cw3bcyZ3soIUX5CPPtQx5
-        OvrpuDbfWFzrJz8T1c0xfdsSzZftsVxJL82hfNMSynp/0BHG1S1IgXY6fHYUN4aqoSaCrmBtCRKe
-        GBFkOYgLez75Mru2n+X4Fc923oJnW2/Ms08tXcmCL3NuZ+K+EecWdeoHnNvsv7Jzg4T/5L7tjq9u
-        xq/k2fzP11qnNmYsYo2tWlsbJkYUs/eGZ3KJEtgVdJB4JeCbaCNOOFyhGaMrGiIaLiO2FoeO0pgD
-        IBgQsicyCv+hZL9QFECgIPO4Opvw1Hyvf2EWgkmtKwLNTjmAkCtQHSppJKl0IMg7whygcxoEs+UU
-        +7DmJn+SgjWXu9LqAcEOEsJAPVJhNvQ/fMaAhL4bVbgKhfcSogPhq4Ww0htnU1jHusri+yI+p8QZ
-        XLWv9CqX02ltAW3dZwXu7nsqZFh7nW8rdH5I+7ivbv6CEbp6SIpEp4xsDWTAMs/vyuolqZq775pI
-        wtKutoQczFTT5tR7WEcQFnXKTRRDYikdxTLNQQOrcZsZZPs+gxg3OGxA64qcKFzxJ8jekna+2WaO
-        sk3Emr1RSg4HBJSYXTWywWZdSpmR6+lC1SBtJFXRYd8cGm3URlklXNbWhLhCVxiy5iJhhCQHxtT1
-        lTkdIvOyd0BdTjkga2mlrqeAWoXk6CEFOadROg48WzOJXBdLgB0qib0RVhGqiVIVqtVMXakCpe2Y
-        KlUTozlDZZisVQdel6fAOxTiL+IjnOD2+uOkcRKtodYRqB2GSLLmcd9opZiCUqkACsPiDKMvd3nc
-        8Wns8fXKlwkF/FQS5SqepaLFhnhUbaErvb4aVc/iN/Qg7Q1CrZC+rEGANvNiPp5cfnYV1jPrfmct
-        VWr/y6roa5fRSqZ6QRmtZ6umGlrPV4dr6HvRey9670VPQf/3RW/xQDcb5QX0UC3K/inKxf4DTZEx
-        YQXrDQ532Uu4ZZ0WzyGV8y81+YtvmSm18XJJ4Ay2ZJRdnPBCbPT0055uuLr+SfyW5Lz0PId6kZIA
-        tlqVQHNpAk7KK9ySlLcCo/HC1eQ9FRdo+RmNJvOxU2FwgUXQXoGR+jT5ZyfxGl5+clKAltqRMeaE
-        24ejKWzsL4yUE9Tkhz/yjQ21fI8o0UWUMo8sdnFC1goAJ72mifQtDm9J+fqm2VvML9/qWoo7q/wg
-        1T0Xjrd3uaz1kRa4X97HD0//AdUtBXBdHAAA
+        H4sIAAAAAAAEAO1ZXW/bNhR9L9D/QAh72IA40IeV2H0YoMhu6s2JPVvJtg59oGXaISBLHiUFMYr8
+        911SHyb1YSdNgaVAggAJdA6vyEOee6+kr+/fIaTdxIR5DIejpfYBab6Oz3qmbXWIaeFOt79YdBZW
+        X+8YuLuwbcPHuo61EzGwHNTV7X63e55dnSc4SWMeap76PonjnD0jScpCN1oSwPQ8QpTgwMMPziZK
+        w4RHOu3b++Ax9hMahUAgPOA/HEDoa/anxsmCCOKXk5IzJ/+mJPSJmKhx0jR2TEOigqPwPqI+qQMu
+        vwXb5avQbuaOtgd/SxmNl1TE5KjzWQLHkY+DKuN6cj2UOFMWLVM/cXFC1hHbcZ1OdWnK+IGG6zG5
+        J4GQ13M8eTTA3m4r5uVNLhzXnUjgDGKWqPNXBZmniyQH3dGlM5NgFwd+GmChMVBGoTglrnpfHkPM
+        1jR6evaj4H+kOExowldk9CpLKvfeOu2bCjJ8IJstv3F+02vppgOyIoyRZQM0xwGJYfgFjkkZXBFy
+        DHsbxuQ63SwI48Ol0dwN2VEly1scpEIUUzd1w7Z1Xb4NxMCMRuJgmZZhWL1+HYV5XLIo3QqWfW52
+        65TihALhTN2WAYl9Rrf784S4uQhy6RozBKHRz0Ps3/2COuhXZKHxIkZbwpDB5UewCEwDNGWwWIB/
+        AgVseV9TkC/0d9kxHsgKhDSZrK4IjlMmVj90P8nrhrPCbZsrfyNDwvqFORzXG93KB7Q4BfnICy1D
+        Hk9e7Gvzlfla777E1c2evmlx82W7lyvppdnK0xYr6/bZARtXlyAZ7bz3ZBc3WtVQE8F3MWuLm3gG
+        RZAOwUDObPR5cu08ySEVC7gvsMAeGgoAVlQM/n72sF6ZPc4tXdmd5znEHXmvxCGi2H2DQ0z7R3EI
+        aP13bhBveDUdvkJ78D9faj3jkLGINTaNbQ2hGFEE7/T6crEU2BX0sngt4Gm0FcckXKMJo2saIhqu
+        IrYRJwelMQdATCBkV2QU/kPJfqIoALch87R6N3Hccx3+xCyEkNohG5sH5QBCrkB1qKSRpNKRTHEg
+        VwB0QYNgshrjJcy56VBKjs/lrjSdQHCChDBQj1SYDUeX3zEg4dKLKlyFwrsa0Qvx2YI39ca7KaxT
+        XWXxdZElp8QZXI2vdE1T5/fmFTUw3dpU2zrmCny4V6uQYQZ1vqPQ+Xbu00xVpo+M0PVdUuRVZWRr
+        OgAs88ihIlKSqqXitokkIu1qU8jBTDVtRv27TQQGqlOmUQzpqTxSlmmeNbAal5lBznLJIBsYHDag
+        3UZuFK75FeTck3a+2RaOsm3Ems+tlEaOCCgxD5Xkhph1KWVGrqcHRYq0kVRFe7bZM9qojbJKuKyt
+        CQ5EVxjy6zxhhCRHxtT1lTkHROZV9oi6nHJE1jJKXU8BtQrJ0WMKck6jdBx4smYSuS6WAA+oJNZG
+        WEWoJkpVqNYwdaUKlLZjqlRNjOYMlWGyVgfwujwFfkAh3m0NcILbK5Wbxkm0gapIoMoYIsmap7bR
+        SjEFpVIBFIbFGYYtN5X84NPY5/OVX4AU8GNJlOt9lormW+JTtWOvPFqornoSv6FbaW8laiX3ea0E
+        NKsfZ8PR5SdPYT2xQzhYS9sr+NEq+n+X0UqmekYZrWerphpaz1fHa+hb0Xsrem9FT0F/+KI3v6Pb
+        rfKoeqwWZf8U5WL/TanImDCDzRaHu+xx3bLOi+uQyvnXpfwRucyU2nC1IrAH92SQvafhhdjs6N2O
+        ee7p+gfxW5Lz0vMU6seUBPLrh3LGNIFDyivcipTvDwbDuafJayre1+V7NBjNhm6FwQUWpr2CIPXb
+        5J/KxAN7+ZlMAVpqR8aYER4ftqaIsX8/peygJl/8ls+CqOWlU4nOo5T5ZL6LE7JRANjpDU2k74f4
+        npSPb5pzj/m7vrqW4hVZvpHqmouDtz9yWesjTXA/vffvHv8DOgBw8hAdAAA=
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -83,7 +83,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1452'
+      - '1469'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -94,7 +94,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jul 2021 16:55:03 GMT
+      - Wed, 27 Apr 2022 13:28:14 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -103,10 +103,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/cassettes/test_avatax_excise/test_calculate_order_line_unit.yaml
+++ b/excise/tests/cassettes/test_avatax_excise/test_calculate_order_line_unit.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2022-02-02", "InvoiceDate": "2022-02-02", "TitleTransferCode":
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
       "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": -1,
       "ProductCode": "202015500", "UnitPrice": "30.000", "UnitOfMeasure": "PAC", "BilledUnits":
       "3", "LineAmount": "30.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
@@ -14,7 +14,7 @@ interactions:
       "OriginCity": null, "OriginPostalCode": null, "OriginAddress1": null, "OriginAddress2":
       null, "UserData": "202015500", "CustomString1": null, "CustomString2": null,
       "CustomString3": null, "CustomNumeric1": null, "CustomNumeric2": null, "CustomNumeric3":
-      null}, {"InvoiceLine": 3, "ProductCode": "202015500", "UnitPrice": "30.000",
+      null}, {"InvoiceLine": 1, "ProductCode": "202015500", "UnitPrice": "30.000",
       "UnitOfMeasure": "PAC", "BilledUnits": "3", "LineAmount": "30.000", "AlternateUnitPrice":
       "1.000", "TaxIncluded": true, "UnitQuantity": null, "UnitQuantityUnitOfMeasure":
       "EA", "DestinationCountryCode": "USA", "DestinationJurisdiction": "VA", "DestinationAddress1":
@@ -26,7 +26,7 @@ interactions:
       "OriginCity": null, "OriginPostalCode": null, "OriginAddress1": null, "OriginAddress2":
       null, "UserData": "202015500", "CustomString1": null, "CustomString2": null,
       "CustomString3": null, "CustomNumeric1": null, "CustomNumeric2": null, "CustomNumeric3":
-      null}], "InvoiceNumber": "3", "Discount": "0", "UserTranId": null}'
+      null}], "InvoiceNumber": "1", "Discount": "0", "UserTranId": null}'
     headers:
       Accept:
       - '*/*'
@@ -41,7 +41,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.26.0
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -49,29 +49,29 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1aXY/aOBR9r9T/EOV5QCYBhulbJtBpugywJDO7q9U+eJILjRQS1knQoGr+e23n
-        A+eT2alWhRYJCZRzfH3v8b2+xsrX9+8kSX4IgVgE+4Yjf5BkBQYKqMNexxmNoNN/QmpndK0oHRWD
-        A+gG95F9I1/xgfkg5foGqf1h8tSMcBSHzJQZ2zaEYcpeQhQTXw8coBhKLQQR9iz8rG2C2I/oc7Xb
-        RwfjIbYjN/ApAZjBvxkgSV+TrwonMcKJ/1zlHBP+jcG3gTvau6obO3V9KIKGvwtcG1KgIyA6m4Ps
-        0zDkB1OTD+DnmLih43KjDH0UwWlgY6/MGPQExoIETmxHOo5gHZA9k6mLBI/xs+uvp7ADj6tridYp
-        aO233CdTeLyktrLnd6XnZvwUpdBsPpsIqI49O/Yw15UyDJ9nxqI4HTORuNhXESr6+XuM/ciN6kLI
-        l7rXVZQCMnmGzZbNmc43E+YzsQch5dziEHILyqhbnHlK18wPYRZvnoAwE4IFluVJCoLziL2Yx60g
-        BfUGA4RK0owhtIm7PayjRNW2JpKl/Sl1pEdjeWfMDFF+PSaEZtk+yYmx6DlVmWV5GpQuQrxSslTS
-        dMt4FFchEzEdeStAEw7QkLLBcgK9XH13iSinViLDa1RYn/9WJbphnUiV9NBbqgR1ldH5VAlV+6+0
-        SJaG/ul+Phv/lEWinlqRzO/MxduLxLQ+n0iRoOs3Fgk6nyIxFxPd0KalOpH0OUV+ymrpt1WL0lQt
-        6v9WLJdD17lUyq9y6BqcWIVczlznUyS/yplreGI1cjlynU+NnNmRi30lZSCm+oSQgNTegzXdcfER
-        mfHO6GYgl7B7CEO85vAi2PKk8dfSnLhr15dcfxWQDc8jKQ4ZQIWlhOSJiNJfUnRwVPJo7dGjRnk2
-        nvypDn9g4lOTcltR95r2jqYLix8ar/Ld8Sqty08JqQLloUJOCCpRXhKYuQXbLe5fpY2WUoVQX8Vv
-        +9vb9seXYreu581XU+xQPeqKXdhL06XUjTttWSBoXgSEugslZs2WwGb0wHesoMQtUB58N1oQ6jLr
-        GWxXRGWXwWEcpoTaReWh89U94DAmSWppv9U7W8PUK15kG0aFPNE/NZLpFFW+VqCztTjcs1dC/EjA
-        XX+JsnZTGNq4L+Y51tZbc1Jbjy1a2ldcSMGkK8lL1/6yCWhlVSmLIKT7dJ4PqqIMa1i1YSaQ5pJt
-        QOqzRKiSIxELzCNhl21WYxcZbQIIvGMqCNRaKQRccxxCt80e4/TogVrSA3/NnkjaDo4MUloNtwjN
-        TgxHFGaUI9LmVqqacqhNTEY4piLj1MrHgNfrJrCrgnGwRSkeH5CSWHWUsliNZqpqZajbjBW1qmPU
-        by0JJorVglflyfAWhdjZcYwj3Nwfxm5oMzvC6RZl8EtO/GGdVRHhpr83l8Z6aayXxnpprJfGemms
-        AnbCjTX5kfW+w9tE2e5JXdhssb9PbjVU9Tp7TtsNe68o/Wed75ryZLUCugg7GCeXW8wppYPYx0Lo
-        A//k5LSPHvqkWoZeY+VjDJ54gZMH40Y0g1knX0F+IzGemJYshpvdf6brNzaWE73EYOLzor6nRqrT
-        pO9PQdI9+6gKNLSYhLEEZp8eFzIbh/u+wurK4sO3vCsmNVzh5agZxMQGcx9GsCkANAk2biS8VIZ3
-        kG8osrbD7O60qiW/ckwXshhzlpOHbEyOeIKDB/fev3v5BjePsyAlJwAA
+        H4sIAAAAAAAEAO1aTW/bOBC9F+h/EHSODUqWnbg3RXZTdR3baylpF4s9MBLtEpAlLyUZMYr89yWp
+        D1OfzqaH2q2AIAn0HoczjzMcitD39+8kSX4IEbEJ9E1X/iDJY6SojgbXPfiE3J6mDJzeeAxG9Nca
+        APfa1ZThSL7iA/NBGhiOh4qWPLUiGMUhM2XFjoPCMGWvUBQT3whcRDGQWggi6NnwWd8GsR/R54O+
+        Bo7GQ+hEOPApATGDfzNAkr4nfyqcxAgn/nOVcyz0b4x8B3FHlau6sTPsoyJo+vsAOygFegJisDnI
+        IQ1DfrB0+Qh+jgkOXcyNMvRRBGeBA70yY6gIjCUJ3NiJDBihTUAOTKY+EDyGz9jfzNAeeVxdW7RO
+        Qfuw4z5ZwuMVtZU9vys9t+KnKIXmi/lUQA3oObEHua6UYfo8M5bF6ZiJxEVtAEDRzz9j6Ec4qgsh
+        X2qlr6oFZPqMtjs2ZzrfXJjPgh4KKecWhii3oN70izPP6Jr5IZrH2ydEmAnBAsvyJAWR+wi9mMet
+        AlUZDamRkjQTFDoE747rKFG17alk61+lnvRoru7MuSnKb8SE0Cw7JDkxET2nKrMsT4MyRIhXSpZK
+        umGbj+IqZCKmI28FaMoBGlI2WE6gl6sfLhH13EpkdA0K6/P/qsQw7TOpEgW8pUpAX725nCqhav+V
+        FsnKND7dL+aTX7JIBudWJIs7a/n2IrHsz2dSJOD6jUUCLqdIrOXUMPVZqU4kY0GRX7JatLZqUZuq
+        pTt0dYeu3+XQNTyzCunOXJdTJL/LmWt0ZjXSHbkup0Yu7MjF/iRlIKb6lJCA1N6DNd1x8RGZ8d7N
+        eCiXsHsUhnDD4WWw40njb6QFwRvsS9hfB2TL80iKQwZQYSkheSKi9D8pOjoqebT26FGjPBtP/lSH
+        L5D41KTcVtRK097RdGHxU+NVfzhetXX5KSFVoDxUyAlBJcpLArN2yMHF/au00VKqEOqr+G2vvW0v
+        vhS7xZ63WM+gS/WoK3ZhL02X0jDv9FWBoHsRItRdVGLWbAlsRg/5rh2UuAXKg4+jJaEus7d7tiuC
+        ssvIZRymxKAPykMX63sEw5gkqaX/Ue9sDdOoeJFtGBXy1PjUSKZTVPl6gc7W4njPXgnxI0F48y3K
+        2k1haOO+mOdYW2/NSW09tmjpUHEhBZOuJK+w820b0MqqUpZBSPfpPB8GqjqqYdWGmUA6JruA1GeJ
+        UCUnIhaYJ8Iu26zGLjLaBBB4p1QQqLVSCLjuuoRumwrjKPRALRmBv2FPJH2PTgxSWw23CM1ODCcU
+        ZpQT0uZWqppyqE1MRjilIuPUyseA1+smsKuCcbBFKR4fIiWx6ihlsRrNVNXKUNyMFbWqY9RvLQkm
+        itWCV+XJ8BaF2NlxAiPY3B8mOHSYHeF0CzL4JSf+tM6qinDT603XWLvG2jXWrrF2jbVrrAJ2xo01
+        +SfrfcevibLdk7qw3UH/kNxqDAbX2XPabth3Rembdb5rytP1GtFF2KNJcrnFnFJ7QOup1zYAH/hP
+        Tk776LFPKmXoNVY+xsgTL3DyYHBEM5h18jXKbyQmU8uWxXCz+890/SbmamqUGEx8XtT31Eh1mvT7
+        KZR0Tw1UgYYWkzBWiNmnx4XMxvG+r7C6svjwLd+KSQ1XeDlqBTFxkHUII7QtADQJtjgSPiqDe5Rv
+        KLK+h+zutKolv3JMF7IYc5aTx2xMjniCg0f33r97+Q+uum7IJScAAA==
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -80,7 +80,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1296'
+      - '1294'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 02 Feb 2022 14:34:51 GMT
+      - Wed, 27 Apr 2022 13:54:34 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';

--- a/excise/tests/cassettes/test_avatax_excise/test_order_created.yaml
+++ b/excise/tests/cassettes/test_avatax_excise/test_order_created.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-08", "InvoiceDate": "2021-07-08", "TitleTransferCode":
-      "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 2602,
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
+      "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 1,
       "ProductCode": "202015500", "UnitPrice": "30.000", "UnitOfMeasure": "PAC", "BilledUnits":
       "3", "LineAmount": "30.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
@@ -14,7 +14,7 @@ interactions:
       "OriginCity": "Richmond", "OriginPostalCode": "23226", "OriginAddress1": "1100
       Congress Ave", "OriginAddress2": "", "UserData": "202015500", "CustomString1":
       null, "CustomString2": null, "CustomString3": null, "CustomNumeric1": null,
-      "CustomNumeric2": null, "CustomNumeric3": null}, {"InvoiceLine": 2603, "ProductCode":
+      "CustomNumeric2": null, "CustomNumeric3": null}, {"InvoiceLine": 2, "ProductCode":
       "202015500", "UnitPrice": "40.000", "UnitOfMeasure": "PAC", "BilledUnits": "2",
       "LineAmount": "40.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
@@ -27,23 +27,23 @@ interactions:
       "OriginCity": "Richmond", "OriginPostalCode": "23226", "OriginAddress1": "1100
       Congress Ave", "OriginAddress2": "", "UserData": "202015500", "CustomString1":
       null, "CustomString2": null, "CustomString3": null, "CustomNumeric1": null,
-      "CustomNumeric2": null, "CustomNumeric3": null}], "InvoiceNumber": "2005", "Discount":
+      "CustomNumeric2": null, "CustomNumeric3": null}], "InvoiceNumber": "1", "Discount":
       "0", "UserTranId": null}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '2272'
+      - '2263'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -51,28 +51,28 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1aXW+jOBR9H2n+A+K5iQwkkM4bJZkOs2mSDbSa0WofXHAylghkDUSNRv3va/Np
-        PkI6rWaVbCNVSuVzuLaP7/E1Fj8/fhAE8T5ExCbQN13xkyAOB8pqoEqj3nC4WvUGA03tQU1xeq40
-        1B41Ba3QtSteJQ8WDw2kkawo13LabEUwikMWy4odB4VhRl+iKCa+EbiIYiALEUTQs+GTvgliP6Lt
-        Sv9aLaOH0Ilw4FMCYgH/YoAg/Ex/Gpw0SEL8+6rgWOifGPkOSkYqXbU9O8U+qoKmvwuwgzJAVoFc
-        YgbrheyziYj3li6W4NeY4NDFSViGPvDgNHCgV2cMJY6xIIEbO5EBI7QOyJ4J1QfcmOET9tdTtENe
-        oq/NR6egvd8mY7K45iWNlbff1tqt+DHKoNl8NuFQA3pO7MFEWcow/SQ5FtXuWIh0iAMFgOo4/4yh
-        H+GobQrFYkt9Wa4gkye02bI+s/5mXH8W9FBIOTcwREUEedSv9jylq+aHaBZvHhFhIbgILNHTJETu
-        A/TiZN4ykIE0HAJQk2aMQofgbbmOAlXbngi2/k3oCQ/m8tacmbz8RkwIzbN9mhNjfuRUZZbn2aQM
-        Hkq8kqeSbtjmA78KuYjZkzdiijxfvdkI8ukZQdVAZRV+zQuGaZ+IFyTwGi+Avjw6Hy9Qtb9nVlia
-        xpe7+Wx8tlZQTs8K81tr8XorWPbXE7EC0F5pBXA+VrAWE8PUpzU3CMacImfriUGXJ+QOTyi/zRPv
-        +pykvvGcpGh9bXA5J/26EYanZ4T3fk5S3nhO+i+98H86J6mnZ4V3f05Sz8cKJ3hOYj9ptvMZPSEk
-        IJwTeIy2Zg6qe4C7n+JcduSdovutgqI32PPmqyl0ad62LQqX89nkDfNWX1YIuhch4tM1qTFblo71
-        6CHftYMat0K593G0IHTQLINY9oL6kJHLOEwSpQ/qj85XdwiGMUkCL/Q/2gfbwjQao8gXtkGeGF8O
-        kmkXTb5eobPVKE3SmOJngvD6R5RvC5VHD+YvxeYEr7HftQcWpK69sBpp3xhCBqa7h7jEzo9N4Lst
-        lEUQUj8V+aDIstrCap1mCumuS1AYSgyWaD0XjMBfsxZB36HDfPlQOEy2AWlPOrqhRNhPdtQjAnLM
-        IyrWYzal5BldenK8Y6Jy1FZlOfzl8jYfamrMczqEZoXiiMKMckTaIkpT0wTqEpMRjqnIOK3yMeDl
-        unHspmAJ2KFUMj9EamK1UepiHQzTVCtH8WGsqlUbo32nSjFerA68KU+OdyjEjgxjGMHD5WaMQ4fF
-        4Q41IIefC2J3Pa1UzI7T5znU08GReiqffz1tTvFSTy/19FJPL/X0Uk9/bz1N/8nvd8rvN/LNmA5h
-        s4X+Pv1UQlG0vJ1WL/YhR/b+XGzC4mS1QnQRdmicXmWwQUk9oPXAyAbgU/JXkLPKXJZdGYBhHX1J
-        oM8x8qgSdYVEG0c0idnxYMWWP0XHE8sW+Rnnd17ZEo7N5cSoMZj+ia/vaJBmN9k3Kyh9v71Wm8CB
-        opUylojFpweQPEZ5wVNZYJFvfM0HOsKBO5sCtYKYOMjahxHaVACaBxsccR/ywB0qg+o7yC7Lmlom
-        d0zZQlbnnKdlmZDp4Y4bYDm8jx+e/wU9At2HmiQAAA==
+        H4sIAAAAAAAEAO1aXW+bOhi+n7T/gLhuIgP5aHdHCevYSZMs0GpH0y5cMJklAjkGokZT//tsvmI+
+        09OeHSVrpEqp/Dy8th+/j19j8fP9O0EQ70JELAJ9wxE/CKIzlMBo6I56tvvg9gYKdHuXwLV7g4Fi
+        S5dDyb1CjniRPFg8NADDK4qnrWYEozhkoczYtlEYZuwlimLia4GDKAayCEEEPQs+qusg9iParvSv
+        RvvgIbQjHPiUgFjAbwwQhJ/pT42TBkmI3y8Kjon+iZFvo2Sg0kXTs1PsozJo+NsA26gOaKwLsstm
+        Id6ZqrgHP8cEhw5OYjL0ngengQ29KmMocYwFCZzYjjQYoVVAdkylPuAGDB+xv5qiLfIScS0+OgWt
+        3SYZk8k1L2msvP2m0m7GD1EGzeYznUM16NmxBxNZKcPwk8RYlLtjIdIhDhQAyuP8EkM/wlHTFIqV
+        lvqyXEL0R7TesD6z/mZcfyb0UEg51zBERQT5sl/ueUqXzA/RLF4/IMJCcBFYkqcZiJx76MXJvGUg
+        A2k4BKAizQSFNsGb/ToKVG1LFyz1q9AT7o3ljTEzePm1mBCaZLs0Jyb8yKnKLMmzSWk8lBglTyVV
+        s4x7fhVyEbMnrzlITwA6pfxhMYWeLl7tEPnIHDIag9Ly/DuTaIZ1JCaRwEtMAvry5emYhKr9d+aR
+        paF9up3PJn+kR5Qj88j8xly83COm9flIPALGL/QIOB2PmAtdM9RpxSaCNqfIH2mWQZdZ5DazyL/N
+        LG/6yDV65ZFLGffHg/OR6791yPDIHPLWj1zKK49c/6dJ3sqRa3RkHnnzR67R6XjkxI5c7Ce1AZ/q
+        OiEB4SzCY7Q1s1bVHNytGWe/A+8tHW8uFLrGnjd3p9ChCd20WpwZsolpxo26LBFUL0LEp4tVYTas
+        KevRQ75jBRVuiXLn42hB6IhZarG0BtUhI4dxmB5KH1Qfnbu3CIYxSQIv1L+aB9vA1GqjyFe8Rta1
+        T61k2kWdr5bobCn27qlN8SNBePUjyveL0qOtiU2xOcEr7HdtjgWpa5MsR9rVhpCB6bYiLrH9Yx34
+        TgNlEYTUaEU+KLI8amA1TjOFVMchKAwlBkv0BCBogb9iLYK6Re18uS0cJpuANCcd3Wki7Cdb7QEB
+        OeYBFasx61LyjC49Od4hUTlqo7Ic/nx56w/VNeY5HUKzCnJAYUY5IG0Rpa5pAnWJyQiHVGScRvkY
+        8HzdOHZdsATsUCqZHyIVsZooVbFaw9TVylHcjpW1amI071QpxovVgdflyfEOhdhZYgIj2F5uJji0
+        WRzutANy+KkgdhdTmQ/YdiY9hWI6OFBM5dMvpvUpnovpuZiei+m5mJ6L6e8tpuk/+ZXP/nOSfDOm
+        Q1hvoL9LP91QlHHeTqsX+7Ake6suNmFRd11EF2GLJukFBxuU3AODnjy2APiQ/BXkrCzvy65UhZ4T
+        5WOMPP4lvpgMjmgGs4OBy9Y+RSe6aYn8dPM7sGz9JsZS1yoMJn5i6lsapN5N9gENSt9sr0Z1oKVi
+        pYwlYvHp6SOPsb/zKa2uyDe+5GMhoeUap0DNICY2MndhhNYlgCbBGkfcV0VwywVVt5Ddn9W1TK6d
+        soUszznPyX02psc6boD74b1/9/QL1ViYTiYlAAA=
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -81,7 +81,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1228'
+      - '1226'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 08 Jul 2021 20:44:28 GMT
+      - Wed, 27 Apr 2022 13:28:12 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -101,10 +101,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/cassettes/test_avatax_excise/test_preprocess_order_creation_wrong_data.yaml
+++ b/excise/tests/cassettes/test_avatax_excise/test_preprocess_order_creation_wrong_data.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-01", "InvoiceDate": "2021-07-01", "TitleTransferCode":
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
       "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 3,
       "ProductCode": "123", "UnitPrice": "30.00", "UnitOfMeasure": null, "BilledUnits":
       "3", "LineAmount": "30.00", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
@@ -32,7 +32,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
@@ -42,7 +42,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -50,25 +50,25 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1Y3W7bNhS+L9B3IHQdp5Ldxq3vFNlpvTm1ZynJgLYXnHRsE5BJj6LcukUu9hh7
-        n+29RlKSR0qykha7GgIESMDv4/n5SJ6To2/PnyHkRBzTaeKM0Evv4qXrvXHP9HIosMgzuexMOGc8
-        QyuW08QpwCWInNOAJSAJPa9YjJjAaYS/+FvJFBJwz0tbykWGY0EYlTgoqx8+NaDCj8IUgtC34peK
-        BX7Pgcagwyy86XW9o4zC6b0evnJq2DVkGV5rONoA2uM0B/TR+eggkiHKBMJqjSRoDJkgFKsw0E85
-        J1lCdEwya46E3JrtICYrAgmKVXb8cF73NYM9pFOqQnTuMKeErg2KkeeMUBWRV2D3Z53Z9k9l67nu
-        oCPd9wyFMVDMCUMcYsaT4gDPETJP47CDERpPl5MgQnNO1oSa2Y/QrV8uB0XWyv0I3YS+qZi9xUSs
-        XYv5DEVEpKADWAEvlseTMJJ7BPBtuWvBWZLHIsAC1owfRuj1GxRCmgKfJvJWoclqBdLZHsaSIReG
-        L1zvRd/te8h1R/oHLYCrE1OkyzyTgmdZkSsKNpjQGaylRh0HGHAiSIzTR52g+tW8zpJQnml9q3HH
-        jXNvd3FmwFO6ZySGEhqY0CVJ0/lqhhN5697n29+Aqywck1KpWl6gYPrWX1oEP5VnIE8AakyvP7B4
-        lynQJGI1lkW5oUQsuIxVxSnLgNvqx2R5kuTWM4JEUZRcg3O3bn++ugac5Vx7X/g/NwL4JcdUEHFQ
-        r0jF4DZMVIyGuUnwzjKnJD+WtUZCVxzIeiPUBWsoEeScy8esgnBuwrGFNV5WQfJbSOYTU6zbNpK2
-        dGiEUIKFEs6SxJstqyq5RVmwTFbwKpD+oN+/aGG1pllAfpJw+dI8fWtkgUIBo2u1gvw9nOb3T5kj
-        fMd4+w1rLzL6Ksxnp5h1FTstNoU0GaWad8t58Pcf/t0pni3pq0HvwvVOcVuFNXBT3eivP+Ov7DNG
-        wwfYTW1NTofAIU7hAWUVpVPSo42mlhrqElERHlRPkVplU8Aj9DJoTaE02KGQzkx1MUukNkqnSKaZ
-        pk4VSk5jtkptjPbKVGCmSh14U54K71DoJgMuezSuukgF3R9J3d2vbxqzu1+jV3xf94v8X6+Wk+nb
-        d9GPtLbOXmG1N5tpF22rqXhuvQH+B13loV7wndX9qRw/leOncvz/KMfhhux2akQ91uTij09nxsyi
-        J9CqKEkP2x2mh2IIHwyG1bqslrEMqZycJpVLxxrT9H+UckTrucOe60XVoHYkl9X9MdSrHFKZSj1F
-        pzFbKlRNl46ZkzH5alzPvjZDCagf5LU00nRTfuaAzKzCNrwEZUPKW33ucI/zi3UKjrlYfFSB5FZ9
-        pbDQkOU8hvCQCdhqQK0XTdTY+e++58/u/wHhv+fz3BEAAA==
+        H4sIAAAAAAAEAO1YzY7aSBC+R8o7tHyGiTFM2OXmMUzCigkIe2ZW2uTQsQtoyXSzbZssG81hHyPv
+        k32v7R+b7cbGM4lyikZCAtX3dVfV1+0qyp9fvkDIiTim08QZoYF7+etgMOgoa5jjvMiE1ZlwzniG
+        VqygiaPBJeQFpwFLQBC6PW2MWI7TCP/lbwUzF4B74XaOHjIc54RRgYPc9Y8PNUj7kZhEEPqsv2Qs
+        8GcBNAYVpfam7GpFGYXT/WV46ZxgN5BleK3gaANoj9MC0HvnvYNIhijLEZY2kqAxZDmhWIaBfis4
+        yRKiYhJZc5SLpdkOYrIikKBYZscPF6e+ZrCHdEpliM495pTQtUEx8pwRKiPqaeyh05qtdy7bnuv2
+        W9J9x1AYA8WcMMQhZjzRB3iBkHkahx2M0Hi6nAQRmnOyJtTMfoTu/NIc6Kyl+xG6DX1TMXuJiVir
+        FvMZikieggpgBVybx5MwEmty4Nty1YKzpIjzAOewZvwwQpceCiFNgU8TcavQZLUC4WwPY8EQhsEr
+        b/jKcz0Pue5IfdACuDwxSboqMiF4lulcUbDBhM5gLTRqOcCAk5zEOH3SCcqv+nUWhPJMT5cad9w4
+        92YXHQOe0j0jMZRQ34SuSJrOVzOciFv3rth+BC6zcExKpWp5gXpe34KvUqBJxE5YFuWWknzBRQTS
+        u3i4XRP0U3GC4vzAZPUEyT2NExJJkSL0L9zT/eerG8BZwZX3N7OZFYDM/FhdahFccyDrTS7PuRZ6
+        UHAunqmDBG7DsYXVLrgm+Q0k86ZL1l0TSe10qIVQgkRDSxJvtqwqqBZlwTJRSKtAvL7nvW5gNaap
+        IT9JuLjwPXXMok6ggNG1tCB/D+f53rntCN8x3nwlmp91SRNP+znmqYqtO9aFNBmlmvfLefDvP/79
+        OZ4t6WW/+9rtneM2CmvgprrR1y/x3+wTRsNH2HVtTU6LwCFO4RFlJaVV0uMedS0V1CaiJDyqniQ1
+        yiaBJ+hl0OpCKbBFIZWZbCaWSE2UVpHMbeo6VSg5j9kqNTGaK5PGTJVa8Lo8Fd6i0G0GXLRKXJX9
+        Cno4ktqbkGduZjehWnH/tiYU+b9fLyfTN2+j7+lFVq+YBG8tgtWPbKZdtK2m0nNPO9YP6CqP9YJv
+        rO7P5fi5HD+X45+jHIcbstvJSfFYk/WPDx1jdFCDYFWUhIftDtODnoX7/WFlF9UyFiGVA8ykculY
+        05L6Rykmpa476HrDqJqXjuSyuj+Fel1AKlI5TdGpjXgSlUOeY+ZkDKAKVyOozZACqgfyRmxSd1O+
+        bYDMrMI2vAS5h5C3euvgHgcO6xQc06jfbUByJ18WWGjICh5DeMhy2CpA2nUTNVb+v+7li4f/AFrI
+        xXliEQAA
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -77,7 +77,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1060'
+      - '1032'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -88,7 +88,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 01 Jul 2021 16:55:06 GMT
+      - Wed, 27 Apr 2022 13:28:13 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -97,10 +97,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/cassettes/test_tasks/test_api_post_request_task_with_invalid_productcodes.yaml
+++ b/excise/tests/cassettes/test_tasks/test_api_post_request_task_with_invalid_productcodes.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-09", "InvoiceDate": "2021-07-09", "TitleTransferCode":
-      "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 2776,
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
+      "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 14,
       "ProductCode": "FAKEPROD", "UnitPrice": "30.000", "UnitOfMeasure": "PAC", "BilledUnits":
       "3", "LineAmount": "30.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
@@ -14,7 +14,7 @@ interactions:
       "OriginCity": "Richmond", "OriginPostalCode": "23226", "OriginAddress1": "1100
       Congress Ave", "OriginAddress2": "", "UserData": "FAKEPROD", "CustomString1":
       null, "CustomString2": null, "CustomString3": null, "CustomNumeric1": null,
-      "CustomNumeric2": null, "CustomNumeric3": null}, {"InvoiceLine": 2777, "ProductCode":
+      "CustomNumeric2": null, "CustomNumeric3": null}, {"InvoiceLine": 15, "ProductCode":
       "FAKEPROD", "UnitPrice": "40.000", "UnitOfMeasure": "PAC", "BilledUnits": "2",
       "LineAmount": "40.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
@@ -27,23 +27,23 @@ interactions:
       "OriginCity": "Richmond", "OriginPostalCode": "23226", "OriginAddress1": "1100
       Congress Ave", "OriginAddress2": "", "UserData": "FAKEPROD", "CustomString1":
       null, "CustomString2": null, "CustomString3": null, "CustomNumeric1": null,
-      "CustomNumeric2": null, "CustomNumeric3": null}], "InvoiceNumber": "2092", "Discount":
+      "CustomNumeric2": null, "CustomNumeric3": null}], "InvoiceNumber": "8", "Discount":
       "0", "UserTranId": null}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '2268'
+      - '2261'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -51,21 +51,21 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1YT2/aMBy9V+p3sHKG1gldKb2lQDXWdjAIvaw9eMkPaik4neNURVW/++w4oU4c
-        oNIO0yQkJMDv+ffnxc6L83Z8hJATcMJGkXOJztyLjnvhdVv58EwQkaVy2BlynvAULZKMRY4GpyAy
-        zvpJBJLQdvVgkAgSB+TVX0mmkAA+wa1NipSEgiZM4qCi/ny0IJ1HYQpB6E1/qVrgdwYshLxMnS0f
-        z2cUVTjtXu+LU8PuIE3JMocnPImyUKAH59q/GU6m48GDg6IEUsQSgeCVpgIlHFH9X1X0ArJnjnD3
-        FPdOPey5COPL/HNSz3MLLxCPmCrP6XMqaEhig2M0eUuZKsfV2Lv6spWQhKL5+lRDHkOg5hQtAx6x
-        l4SGUEBet3tuolc0jseLWxJRtvyerX4BV404JqWQrxS71LDCuYqBRUFSo1Yoc0bFhMtKJNKR6wPj
-        eh0QKY7qs3OC61PHizsgacb1FfVvKrH9WABnREADs29V8SMjTFCxtsjD/tetZJnC5vsVupJ4swPs
-        Fq850OWTCNbPtjj9jHO5zNcKmM+q2o45XVK542Rcvi6lnc/8BtK3jNM0ouVKcu6bSHmktVVCAVIN
-        TWn4tErKXV+hTJJU7vayEK/jeecNrMY2NeRHEZe701Ww62KM+glbqhHkv8B2vrctHOXPCW9edANI
-        BZULQ+qxR0CDuUfFekxbSpOxS0+Dt09Ug9qorIF/Xl57kq2xydkh9IzEsEdhRdkj7SaKrWkO7RJT
-        EfapqDiN8ing87oZbFuwHNyhVN4f8JpYTZS6WFvD2GqVKN2OVbVqYjTfqTRmirUDt+Up8R0KzVPg
-        AyJIxW1K/H3D3O2B3k4P7P57Dzzb44He/++BdosHDzx44MEDDx548MC/8kD947FlnBTzA3J5r5UZ
-        Vs+ErfWpudMp7U75WChLKs6rwzKlM1wsID/3ypx63chDbxt327gXlEffDblw0w+r9HDPq6OfCXSd
-        QSwbrQvgBFTINaosfQGbQ/5gOAscs+PytUJxhQaj6bBfYyh58217J4PYaYq3FpCa1lOFp6BiyAeD
-        8u0F3thy5Ro55qB+RwLRPYmzaspZkvEQZutUwCoH1Lh+pDFmfsw7Pnr/A7cXQkirEQAA
+        H4sIAAAAAAAEAO1YT2/aMBy9V+p3sHKGNgRo195SoBprOxiEXtYevOQHtRTiznGqoqrffXYcUycO
+        odIO0yQkJMDv+ffnxc6L83Z8hJATMJyMI+cS9dz+Rf+s18pH5xzzLBWjzogxylK0pFkSOQqcAc9Y
+        MqARCEK7owYDynEc4Fd/LZhcAO6J29pmSHHICU0EDjLqz0cLUnkkJhGE3tSXrAV+Z5CEkFepsuXj
+        +YyiCqd9cdF3KtgdpCle5fCU0SgLOXpwrv2b0XQ2GT44KKKQooRyBK8k5YgyRNR/WdELiJ4Zcnun
+        3vmp53oect3L/HNSzXMLLxCPE1meM2CEkxDHBsdo8pYkspyOwt7ll62EIBTNV6ca8hgC1adoGfA4
+        eaEkBA31TOyKxPFkeYsjkqy+Z+tfwGQbjkkpxNNSawVLnKsYkiigFWqJskgInzJRh0C6YnW4brUO
+        iCRHdtk9catTJ8s7wGnG1PX0b0qx/ZgDSzCHGubAquJHhhNO+MYijwZfd5JFCpvvl+hS4O36t1u8
+        ZkBWTzzYPNviDDLGxCLfSGAxL2s7YWRFxH4TcdlGS7uY+zWkbxkjaUT0OnLu60h5pI1VQgESBc1I
+        +LSmes+XKFOair2uC/G6nndWw6ptU0F+FDGxNzsS7nRcFw1ospIjyH+B3XxvVzjCnimrX3RDSDkR
+        C0PosUdAg7lHxWpMW0qT0aSnwdsnqkGtVdbAPy+vPcnW2OQ0CD3HMexRWFL2SLuNYmuaQ01iSsI+
+        FSWnVj4JfF43g20LloMNSuX9AauIVUepirUzjK2WRslurKxVHaP+TqUwU6wG3JZH4w0KLVJgQ8xx
+        yW00/r5lNjug1+CA/X/vgL09Duj9/w5ot3hwwIMDHhzw4IAHB/wrB1Q/HlvGKTE/HOt7rciwfsbJ
+        Rp2Yu91zPS7MKRQlFWfVkU7pjJZLyM+8IqdaN+LA23Z7be880MfeLbnw0g+r/FKFPhPlOoNYdFnt
+        3gkIFwtUuvkStqf74WgeOGa7+n1CcXmG49loUGFIbfM9eyeC2GmK1xWQmr5ThmcgY4inAv3awt16
+        cukCOeagejkC0T2Os3LKOc1YCPNNymGdA3JcPc0YMz/mHR+9/wFDs3gIoxEAAA==
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -74,7 +74,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '849'
+      - '844'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 09 Jul 2021 18:19:26 GMT
+      - Wed, 27 Apr 2022 14:21:35 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -94,10 +94,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/cassettes/test_tasks/test_api_post_request_task_with_valid_productcodes.yaml
+++ b/excise/tests/cassettes/test_tasks/test_api_post_request_task_with_valid_productcodes.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"EffectiveDate": "2021-07-09", "InvoiceDate": "2021-07-09", "TitleTransferCode":
-      "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 2778,
+    body: '{"EffectiveDate": "2022-04-27", "InvoiceDate": "2022-04-27", "TitleTransferCode":
+      "DEST", "TransactionType": "DIRECT", "TransactionLines": [{"InvoiceLine": 13,
       "ProductCode": "202015500", "UnitPrice": "30.000", "UnitOfMeasure": "PAC", "BilledUnits":
       "3", "LineAmount": "30.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
@@ -14,7 +14,7 @@ interactions:
       "OriginCity": "Richmond", "OriginPostalCode": "23226", "OriginAddress1": "1100
       Congress Ave", "OriginAddress2": "", "UserData": "202015500", "CustomString1":
       null, "CustomString2": null, "CustomString3": null, "CustomNumeric1": null,
-      "CustomNumeric2": null, "CustomNumeric3": null}, {"InvoiceLine": 2779, "ProductCode":
+      "CustomNumeric2": null, "CustomNumeric3": null}, {"InvoiceLine": 14, "ProductCode":
       "202015500", "UnitPrice": "40.000", "UnitOfMeasure": "PAC", "BilledUnits": "2",
       "LineAmount": "40.000", "AlternateUnitPrice": "1.000", "TaxIncluded": true,
       "UnitQuantity": null, "UnitQuantityUnitOfMeasure": "EA", "DestinationCountryCode":
@@ -27,23 +27,23 @@ interactions:
       "OriginCity": "Richmond", "OriginPostalCode": "23226", "OriginAddress1": "1100
       Congress Ave", "OriginAddress2": "", "UserData": "202015500", "CustomString1":
       null, "CustomString2": null, "CustomString3": null, "CustomNumeric1": null,
-      "CustomNumeric2": null, "CustomNumeric3": null}], "InvoiceNumber": "2093", "Discount":
+      "CustomNumeric2": null, "CustomNumeric3": null}], "InvoiceNumber": "7", "Discount":
       "0", "UserTranId": null}'
     headers:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
       - keep-alive
       Content-Length:
-      - '2272'
+      - '2265'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
@@ -51,28 +51,28 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1aXW/iOBR9H2n+Q5TngpwEAsxbGphOZimwJK12tdoHNzGMpZCwToKKRv3va+fT
-        +aTTalawg1SJyufk+vrce30dK98/fhAE8SFAxCLQMxzxkyAObSjbKnB6NoBKb2APJz0IB8PeE1CQ
-        5Iw3T7Kqijfxg/lDA2msSGN5nAybIQyjgNkyI9tGQZDS1yiMiKf7DqIYSE34IXQt+Kzt/MgL6bjS
-        n6iF9QDaIfY9SkDM4F8MEITvyU+NkxiJiX/f5BwT/RMhz0axp9JN07Nz7KEyaHgHH9soBeTRaFxg
-        OpuFHNOFiA+mJhbg14jgwMGxWYY+8uDct6FbZQwljrEivhPZoQ5DtPXJkQnVB5zP8Bl72zk6IDfW
-        1+KtU9A67mOfTG54TW1l43eVcTN6ClNosVzMOFSHrh25MFaWMgwvTo5VeTpmInFxoABQ9vP3CHoh
-        DpuWkAdb6styCZk9o92ezZnOt+DmM6GLAsq5hQHKLcjjfnnmOY2aF6BFtHtChJngLLBET5IQOY/Q
-        jeJ1y0AG0nAIQEWaKQpsgvdFHAWqtjUTLO0PoSc8Gus7Y2Hw8usRITTPjklOTHnPqcosz9NF6TwU
-        10qWSppuGY98FDIR0ydvxQR5uXl3IcjnVwjqCJSi8GO1oBvWmdSCBN5SC6Avjy+nFqjaf6alsDb0
-        L/fLxfRiS0E5v1JY3pmrt5eCaX09k1IAozeWAricUjBXM93Q5pVqEPQlRS62JgZdNSF31MTkek76
-        Geck9Z3nJGXUHw2u56QfL4Th+RXCr35OUt55Tvova+H/dE5Sz68Ufvlzkno5pXCG5yT2k2Q7n9Ez
-        QnzCVQKP0dG0gqo1wN1PcVV24p2i+62CorfYdZebOXRo3jYFhcv5dPG6caetSwTNDRHxaEwqzIbQ
-        sRld5DmWX+GWKA8eDleEOs0yiGUvqLqMHMZhkih9UH10ublHMIhIbHil/dbsbANTr3mRBbZGnulf
-        Wsl0ijpfK9FZNIoiqS3xM0F4+y3MtoXSo635S7ElwVvsde2BOalrLyxbOtZcSMFk9xDX2P6282nm
-        1ykrP6D1lOeDIstqA6txmQmkOQ5BQSAxWKL9XNB9b8tGBO2A2vlymzlM9j5pTjq6oYTYi3fUEwJy
-        zBMqVm3WpeQZXXpyvFOictRGZTn89fLWH6przHM6hGaN4oTCjHJC2txKXdMY6hKTEU6pyDiN8jHg
-        9bpx7LpgMdihVLw+RCpiNVGqYrWaqauVobgdK2vVxGjeqRKMF6sDr8uT4R0KsSPDFIawvd1McWAz
-        O9yhBmTwS07s7qcyb7Dj9HkJ/XRwop/Kl99P60u89tNrP73202s/vfbTn9tPk3+y+53i+41sM6Yu
-        7PbQOyafSijKKBun3Yt9yJG+P+ebsDjbbBANwgFNk6sM5pTUA6MemFgAfIr/cnLamYu2K4OJUkVf
-        Y+hzhFyqRFUh0cIhTWJ2PNiw8CfodGZaIr/i7M4rDeHUWM/0CoPpH9f1PTVSnyb9ZgUl77cTtQ60
-        NK2EsUbMPj2AZDaKC55SgEV+8C0f6AgtdzY5avoRsZF5DEK0KwE0D3Y45D7kgQeU7ymidoDssqyu
-        ZXzHlAayvOYsLYuETA53nIOFex8/vPwLjpgmYJokAAA=
+        H4sIAAAAAAAEAO1aXW+jOBR9H2n+A+K5iRwgJJk3SpgOs2mSDbTa1WofHHAySASyBqJGo/73sfk0
+        n+m2O6tkGqlSKp/DtX18j6+x+P7xA8fxDwHCJoaebvOfOF6Wx2uIZKEHxbHdkyYD0JuAtdUTNmMJ
+        rCdjS5bG/E38YP6QBIaT4XCStBohDKOAhjIiy0JBkLJXKIywp/o2IhhII/ghdE34pOz8yAtJu9if
+        yEXwAFqh43uEgGjAvyjAcd+TnxonCRIT/77JOQb6J0KeheKBDm6anp05HiqDunfwHQtlgFggKu0D
+        H9Np8A+Gwhfg1wg7ge3EQSn6yIIz34JulTEcMIwl9u3IClUYoq2Pj1SmPmBGDJ8cbztDB+TG6pps
+        dAKax308JoNpXpFYWftdpd2I1mEKzRdzjUFV6FqRC2NdCUP34sxYlrujIZIhSiIA5XH+HkEvdMKm
+        KeRLPegLQgnRntBuT/tM+5sz/RnQRQHh3MIA5RGEcb/c84ysmRegebRbI0xDMBFolicpiOxH6Ebx
+        vAUggMFwCEBFmikKLOzsi3XkiNqmxpnKH1yPe9RXd/pcZ+VXI4xJlh2TnJiyIycq0yxPJ6WyUOyU
+        LJUU1dQf2VXIREyfvGUgLQbIlLKH+QR6vnmzRYRzs4g8AqX1+XcuUXXzTFwyAK9xCegL48txCVH7
+        z9QkK139cr+YT39Jk4jnZpLFnbF8vUkM8+uZmASMXmkScDkmMZaaqiuzik84dUGQX9ItUpdbhFa3
+        SD/NLe/61CW/8dQljvoj6Xrq+m8tMjw3i7z3U5f4xlPX/+mS93Lqks/NJO/+1CVfjkku7NRFfxIf
+        sLmuYexjxiMsRlpTb1XdwdydMf478e7S9fZCsFvHdRebGbRJRjctF+OGdGaqfqesSgTFDRH2yGpV
+        mA2LSnt0kWebfoVbojx4TrjEZMg0t2heg+qQkU05VBCxD6qPLjb3CAYRjgMvld+aB9vAVGujyJa8
+        RtbUL61k0kWdr5TodC0K+9Sm+BkjZ/stzDaM0qOtmU2wBXa2jte1O+akrl2yHOlYG0IKJvsKv3Ks
+        bzufeKJOWfoBcVqeD6IgyA2sxmkmkGLbGAXBgMIDcgbgVN/b0hZOOaB2vtAWzsF7HzcnHdlqQseL
+        99oTAjLMEypWY9alZBldejK8U6Iy1EZlGfzl8tYfqmvMcjqEpiXkhMKUckLaPEpd0xjqEpMSTqlI
+        OY3yUeDlujHsumAx2KFUPD+EK2I1UapitYapq5WhTjtW1qqJ0bxTJRgrVgdelyfDOxSih4kpDGF7
+        uZk6gUXjMMcdkMHPObG7mgpswNZT6SVUU+lENRUuv5rWp3itptdqeq2m12p6raY/t5om/2S3PsVn
+        JdlmTIaw20PvmHzCIYqjrJ1UL/qBSfpenW/CvLbZILIIBzRNrjjooIQekHrCyATgU/yXk9O6XJTd
+        URV6SZTPEXLZ1/h8Mk5IMpieDDZ07RN0qhkmz043uwZL12+qrzS1wqDix6a+J0Hq3aQf0qDk1XYi
+        14GWipUwVojGJ6ePLEZx61NaXZ5tfM1HQ1zLRU6OGn6ELWQcgxDtSgBJgp0TMl8XwQPKNxReOUB6
+        g1bXMr54SheyPOcsJ4tsTM51zACL4X388PwDb46cPy4lAAA=
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -81,7 +81,7 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Length:
-      - '1229'
+      - '1232'
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' use.typekit.net fonts.gstatic.com
         data: ; img-src ''self'' p.typekit.net *.walkme.com *.cloudfront.net data:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 09 Jul 2021 18:19:28 GMT
+      - Wed, 27 Apr 2022 14:19:22 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -101,10 +101,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -116,7 +120,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Authorization:
       - Basic Og==
       Connection:
@@ -126,37 +130,37 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.1
       x-company-id:
       - '1337'
     method: POST
-    uri: https://excisesbx.avalara.com/api/v1/AvaTaxExcise/transactions/5ca2c60d-c0a3-4c59-aa45-b03e1d8fb266/commit
+    uri: https://excisesbx.avalara.com/api/v1/AvaTaxExcise/transactions/668bae62-a38d-4910-90bc-2f840b98c648/commit
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEAO1aW2/iOBh9H2n+Q5TngnLhOm9pYDqZpcCStNrVah/c5INaCgnrJKho1P8+dm44
-        FwLTandhhqoSrc/JZ/v4O/6MlW8fPwiC+BAAsQjyDEf8JIhdGyl2T3JatoTUVsfuDlsIdbqtJ0kF
-        2Rksn5ReT7yJH8wf6sgDVR4og6TZDFEYBSyWGdk2BEFKX0AYEU/3HaCYlIbwQ+Ra6EVb+5EX0na1
-        PexJ9GffQ4DsEPseJQEL+hcDBOFb8lHhJIFi4t83OceEfyLwbIhHK9/UPTvBHhRBw9v62IYUUPr9
-        wR7TWS9kl05GfDA1cQ9+jQgOHByHZegjD058G7llRlfmGHPiO5Ed6iiElU92TKy2xI0ZvWBvNYEt
-        uLHGFh+dgtZuE4/J5JoXNFbWfldqN6OnMIWms+mYQ3Xk2pGLYmUpw/DiBJkXu2MhkiF21GzdMuz3
-        CHkhDuumkC+43FaU0mPjF1hvWK9pj1OuRxO5EFDOLQogj6EM2sW+J3TdvACm0foJCAvBRWDpnqQi
-        OI/IjeKZK5Iiyd2uJJXEGUFgE7zZr6RA9bbGgqX9IbSER2NxZ0wNfgH0iBCaabskK0b8yKnOLNvT
-        Sek8FDsmSyZNt4xHfh0yGdMnb8UEeb15txWU87NCry8VVuHH3KAb1pm4QZbe4gaprQwuyQ1U7z9T
-        MywM/cv9bDq6WDOo52eG2Z05f7sZTOvrmZhB6r/RDOXHztoM5nysG9qk5AdBn1HkYl3RaXKF0uCK
-        4fW09G+clnrvPi2p/Xa/cz0t/bgVuudnhV/9tKS++7T0X7rhZzot9c7PDL/8aal3SWY4w9MS+0jy
-        nc/pMSE+4bzAY7Q19VDZBdxdFeczypsRvMKeuQEbF1O4ZDdKpaKF2Ivz5iQ+W9OTiE3fb5q/4VD0
-        FrvubDlBDnVPXWJwzksXQDfutEWBoLkhEDozKDFr0of16ILnWH6JW6A8eDicEzpolsXMQ4WCko4a
-        HEZjcqg1DIbNlveAgojEHcy13+oHXcPUK6PJkqxCHutfDpJpF1W+VqCzVdkbNptqeTKfCeDVc5jt
-        VYUIBy2VZ2fTxpyTmjboYqRdZQgpmGxp4gLbz2ufmrFKmfsBtXieHqqi9GpYtdNMIM1xCASBzGCZ
-        HjME3fdWrEXQtnCYrxwKh8nGJ/U5yNn1iIAc84iK5ZhVKXlGk54c75ioHLVWWQ4/Xd7qQ1WNeU6D
-        0GyfO6IwoxyRNo9S1TSGmsRkhGMqMk6tfAw4XTeOXRUsBhuUiucHpCRWHaUs1sEwVbUyFB/GilrV
-        Mep3qgTjxWrAq/JkeINC7BQzQiE6XH1GOLBZHO6kxXbbjPGac8+/yis83HAyv4Qq3zle5ZWfpMp3
-        rlX+WuWvVf5a5a9V/n+r8skfWX0t3A+82M/IWwG75igU4QMvyMQjXm+Qt0teR1HVftZOax97YSa9
-        l8j3bHG8XALtawuj5JKIzUFuSf2WNLQk6VP8m5PTur4v2oo0VMvoKYE+R+BS4cqCihYOac4zAZYs
-        WxJ0NDYtsUadbMVHxmKslxhsueJt4J4GqXaTvhsEyRd27r2gAnigziWMBbA+6BEmi1M6NBQSQ+Qb
-        3/JGlHDgUixHTT8iNpi7IIR1AaAJscbh/s2p5P8Q8v1I1LaI3UlWhY0v8tJVLU4+S+lCMifHVW6c
-        +1F+/PD6HQrsBCcSJgAA
+        H4sIAAAAAAAEAO1aW2/iOBh9H2n+Q5TngkISAsxbGphOZimwJK12tdoHNzHUUkhYx0FFo/73sXPD
+        ucK2e6EtVSVan5PP9vF3/BkrPz5/EgTxLoTYxsA3XfGLIGra8AFATe4AZeh21FFP6oykB6cjr4aq
+        9DAaOpo6FK/iB/OHVKk/6vdHSatFAIlCFsqKHAeGYcpeQhJh3whcSDEpjRAQ4NngSd8EkU9ou9Id
+        aRL9OXQQAoegwKckyIL+wQBB+JF8VDhJoJj451XOseBfEfQdGA+2d1X37BT5sAia/i5ADswA5YAY
+        rA+8T6ci3lm6eAC/RxiFLoqDMvSeB6eBA7wyo9/jGAscuJFDDEDgOsB7JlVX4kYMnpC/nsId9GKF
+        bT46Be39Nh6TxTUvaays/abUbkUPJIVm89mEQw3gOZEHYl0pw/Tj7FgUu2MhkiGqSrZqGfZrBHyC
+        SN0U8uXudWW59NjkCW62rNe0xxnXowU8GFLONQhhHkMedot9T+mq+SGcRZsHiFkILgLL9SQRoXsP
+        vCieuSzJUq/fl6SSOGMYOhhtDyspUL3tiWDrvwkd4d5c3pgzk18AI8KY5tk+yYoxP3KqM8v1dFIG
+        D8V+yZJJN2zznl+HTMb0yWsOmsQAnVL2sJhAz1evNol8bibRBlJhff6eTwzTPhOf9KSX+ETqysO3
+        5BOq9++pTZam8e12Phu/S5so52aT+Y21eLlNLPv7mdhEGrzQJuXHztom1mJimPq05BTBmFPkXfpF
+        bfOL3OgX9V/zy4c+e2mvPnspg+5AvZy9/lmT9M/NJB/97KW8+uz1X/rko5y9tHOzyYc/e2lvySZv
+        7OzFPhIn8Nk+wTjAnEt4jLam7ir7g7tH4xxIeXOM1si3ttBBxfQuGZFSqaAE+XFOncRn630Sse17
+        VNs3KYpdI8+br6bApb6qSxnOk6m6hnmjLwsE3SMQ03nBErMmsViPHvRdOyhxC5Q7H5EFpkNm+c3c
+        VShC6aihy2hMDKWGwbD56haCMMJxBwv9l/pB1zCNymiy9KuQJ8a3RjLtosrXC3S2JgcrZ1MtT+Yr
+        hmj9SLJdrBCh0Wx5brZt2TmpbesuRtpXhpCCyWYnLpHzuAmoTauURRBS8+fpociyVsOqnWYC6a6L
+        YRj2GNyjRxPBCPw1axH0HWzmy03hEN4GuD4HObMeEZBjHlGxHLMqJc9o05PjHROVo9Yqy+Gny1t9
+        qKoxz2kRmu1yRxRmlCPS5lGqmsZQm5iMcExFxqmVjwGn68axq4LFYItS8fwgLolVRymL1RimqlaG
+        omasqFUdo36nSjBerBa8Kk+GtyjEzjdjQEBz9Rmj0GFxuDOYlMHPOfH8C7zMw43H9bdQ4NXjBV5+
+        JwVevRT4S4G/FPhLgb8U+P+nwCd/ZKW1cCvw5DwCfw3ZxUeh/ta/sROPdrMF/j55P0ZRBlk7rXvs
+        DZ70oiLfr8XJagVpVzs4Tm6N2PjljqR25IEtSV/i35ycVvRDwR6UoVOifI2gx9+L5FNChCY7m/yK
+        pUmCjieWLdYoky312FxOjBKDrVPs/1sapNpN+qYSTL6kc28pFcCGApcwlpD1Qc8uWZzSaaGQESLf
+        +JLXs4SGK7IctYIIO9DahwRuCgDNhg0ih/e4kv8JzDciUd8BdkNZFTa+1ktXtTj5LJcPWZwcUblB
+        Hob4+dPzTwlO4/OcJgAA
     headers:
       Cache-Control:
       - no-store, no-cache
@@ -176,7 +180,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 09 Jul 2021 18:19:29 GMT
+      - Wed, 27 Apr 2022 14:19:27 GMT
       Feature-Policy:
       - geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr
         'self'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none';
@@ -185,10 +189,14 @@ interactions:
       - strict-origin-when-cross-origin
       Server:
       - ''
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/excise/tests/test_avatax_excise.py
+++ b/excise/tests/test_avatax_excise.py
@@ -656,7 +656,6 @@ def test_calculate_order_line_unit(
 
     site_settings.company_address = address_usa_va
     site_settings.save()
-
     order_line.id = -1
     order_line.unit_price = TaxedMoney(
         net=Money("10.00", "USD"), gross=Money("10.00", "USD")

--- a/excise/utils.py
+++ b/excise/utils.py
@@ -529,7 +529,7 @@ def get_order_request_data(order: "Order", config=AvataxConfiguration):
     data = generate_request_data(
         transaction_type=TRANSACTION_TYPE,
         lines=lines,
-        invoice_number=f"{order.pk}",
+        invoice_number=f"{order.number}",
         discount=discount_total.amount,
     )
     return data


### PR DESCRIPTION
The `order` `id` has been changed from `int` to `uuid`. Use `order.number` in request data, as the `order.id` is too long for avatax excise.